### PR TITLE
docs: Improve C++ header documentation quality

### DIFF
--- a/include/fb/abstract.h
+++ b/include/fb/abstract.h
@@ -10,8 +10,12 @@
 namespace fb {
 
 /**
- * @brief      This class describes a context.
+ * @brief      Base context class for managing asynchronous operations and thread pools.
  *
+ *             This class provides a foundation for managing asynchronous operations using
+ *             Boost.Asio, thread pools, and timer functionality. It maintains thread-safe
+ *             collections of switchable objects and provides timer binding capabilities
+ *             for both thread-based and coroutine-based execution.
  */
 class context
 {
@@ -35,12 +39,15 @@ protected:
 
 protected:
     /**
-     * @brief      Binds a thread timer with a member function callback.
+     * @brief      Binds a member function as a thread-based timer callback.
      *
-     * @param[in]  fn        The member function to bind as timer callback.
-     * @param[in]  duration  The duration between timer executions.
+     *             Creates a timer that executes the specified member function at regular
+     *             intervals on the thread pool. The callback receives timing information
+     *             and thread ID for context-aware processing.
      *
-     * @tparam     Class     The class containing the member function.
+     * @tparam     Class     The class type containing the member function
+     * @param[in]  fn        The member function to execute as timer callback
+     * @param[in]  duration  The time interval between timer executions
      */
     template <typename Class>
     void bind_thread_timer(async::task<void> (Class::*fn)(const fb::model::datetime&, std::thread::id),
@@ -51,12 +58,15 @@ protected:
     }
 
     /**
-     * @brief      Binds a timer with a member function callback.
+     * @brief      Binds a member function as a coroutine-based timer callback.
      *
-     * @param[in]  fn        The member function to bind as timer callback.
-     * @param[in]  interval  The interval between timer executions.
+     *             Creates a coroutine-based timer that executes the specified member function
+     *             at regular intervals using Boost.Asio's coroutine support. The timer runs
+     *             asynchronously and continues until the context is stopped.
      *
-     * @tparam     Class     The class containing the member function.
+     * @tparam     Class     The class type containing the member function
+     * @param[in]  fn        The member function to execute as timer callback
+     * @param[in]  interval  The time interval between timer executions
      */
     template <typename Class>
     void bind_timer(async::task<void> (Class::*fn)(void), std::chrono::steady_clock::duration interval)
@@ -99,24 +109,35 @@ public:
 };
 
 /**
- * @brief      This class describes an acceptable.
+ * @brief      TCP acceptor context for handling incoming network connections.
+ *
+ *             This class extends the base context to provide TCP server functionality,
+ *             combining asynchronous I/O operations with thread pool management.
+ *             It inherits from both context and Boost.Asio's TCP acceptor to provide
+ *             a complete server foundation.
  */
 class acceptable : public context, public boost::asio::ip::tcp::acceptor
 {
 protected:
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Constructs a new TCP acceptor context.
      *
-     * @param[in]  context  The context.
-     * @param[in]  name  The name.
-     * @param[in]  thread_count  The thread count.
-     * @param[in]  port  The port.
+     *             Creates a new acceptor context that listens on the specified port
+     *             and manages a thread pool for handling connections.
+     *
+     * @param[in]  context       The Boost.Asio I/O context for asynchronous operations
+     * @param[in]  name          The name identifier for this acceptor context
+     * @param[in]  thread_count  The number of worker threads to create
+     * @param[in]  port          The TCP port number to listen on
      */
     acceptable(boost::asio::io_context& context, const std::string& name, uint32_t thread_count, uint16_t port);
 
 public:
     /**
-     * @brief      Destroys the acceptable.
+     * @brief      Destroys the acceptor context and cleans up resources.
+     *
+     *             Properly shuts down the acceptor, closes any open connections,
+     *             and releases all associated resources.
      */
     virtual ~acceptable() = default;
 };

--- a/include/fb/concurrent.h
+++ b/include/fb/concurrent.h
@@ -6,23 +6,34 @@
 namespace fb {
 
 /**
- * @brief      This class describes a lock error.
+ * @brief      Exception thrown when a lock operation fails or encounters an error.
+ *
+ *             This exception is typically thrown when deadlock detection fails,
+ *             lock acquisition times out, or other concurrency-related errors occur.
  */
 class lock_error : public std::runtime_error
 {
 public:
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Constructs a new lock_error exception.
+     *
+     *             Initializes the exception with a default error message
+     *             indicating a lock operation failure.
      */
     lock_error();
+
     /**
-     * @brief      Destroys the object.
+     * @brief      Destroys the lock_error exception.
      */
     ~lock_error() = default;
 };
 
 /**
- * @brief      This class describes a concurrent.
+ * @brief      Base class for thread-safe objects with deadlock detection capabilities.
+ *
+ *             This class provides a foundation for implementing thread-safe operations
+ *             with built-in deadlock detection. It maintains a root deadlock detector
+ *             and provides methods to manage and validate lock dependencies.
  */
 class concurrent
 {
@@ -31,26 +42,39 @@ protected:
 
 protected:
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Constructs a new concurrent object.
+     *
+     *             Initializes the deadlock detection system for this concurrent object.
      */
     concurrent() = default;
+
     /**
-     * @brief      Destroys the object.
+     * @brief      Destroys the concurrent object.
+     *
+     *             Cleans up any deadlock detection resources.
      */
     ~concurrent() = default;
 
 protected:
     /**
-     * @brief      Adds the specified node.
+     * @brief      Adds a deadlock detector node to the dependency graph.
      *
-     * @param      node  The node
+     *             Registers a new node in the deadlock detection system, establishing
+     *             it as part of the lock dependency chain for this concurrent object.
+     *
+     * @param[in]  node  The deadlock detector node to add to the dependency graph
      */
     void add(fb::dead_lock_detector& node);
 
     /**
-     * @brief      Checks for deadlock conditions with the specified node.
+     * @brief      Validates that acquiring a lock won't create a deadlock.
      *
-     * @param[in]  node  The dead lock detector node to check.
+     *             Performs deadlock detection analysis to ensure that acquiring
+     *             the lock represented by the specified node won't create a circular
+     *             dependency that could lead to deadlock.
+     *
+     * @param[in]  node  The deadlock detector node to validate
+     * @throws     lock_error if a potential deadlock is detected
      */
     void assert_dead_lock(const fb::dead_lock_detector& node);
 };

--- a/include/fb/game/clan.h
+++ b/include/fb/game/clan.h
@@ -41,26 +41,38 @@ private:
 
 public:
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Constructs a new clan with the specified context and identifier.
      *
-     * @param      context  The game context that manages this clan
+     *             Creates a new clan object managed by the given game context.
+     *             The clan starts with no members and must be populated through
+     *             the update() method or by adding members individually.
+     *
+     * @param[in]  context  The game context that manages this clan
      * @param[in]  id       The unique identifier for this clan
      */
     clan(context& context, uint32_t id);
+
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Copy constructor (deleted).
      *
-     * @param[in]  <unnamed>  The source clan object (copy constructor is deleted)
+     *             Clans cannot be copied to prevent resource management issues
+     *             and maintain unique clan identity within the game context.
      */
     clan(const clan&) = delete;
+
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Move constructor for transferring clan ownership.
      *
-     * @param      <unnamed>  The source clan object to move from
+     *             Allows moving a clan object while preserving all member data,
+     *             character associations, and clan properties.
      */
     clan(clan&&);
+
     /**
-     * @brief      Destroys the object.
+     * @brief      Destroys the clan and cleans up member associations.
+     *
+     *             Detaches all associated characters and cleans up clan resources
+     *             when the clan object is destroyed.
      */
     ~clan() = default;
 

--- a/include/fb/game/group.h
+++ b/include/fb/game/group.h
@@ -39,29 +39,40 @@ private:
 
 public:
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Constructs a new player group with the specified context and identifier.
      *
-     * @param      context  The game context that manages this group
+     *             Creates a new group object managed by the given game context.
+     *             The group starts empty and must be populated with members through
+     *             the update() method or by characters entering individually.
+     *
+     * @param[in]  context  The game context that manages this group
      * @param[in]  id       The unique identifier for this group
      */
     group(context& context, uint32_t id);
 
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Copy constructor (deleted).
      *
-     * @param[in]  <unnamed>  The source group object (copy constructor is deleted)
+     *             Groups cannot be copied to prevent resource management issues
+     *             and maintain unique group identity within the game context.
      */
     group(const group&) = delete;
 
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Move constructor for transferring group ownership.
      *
-     * @param      g     The source group object to move from
+     *             Allows moving a group object while preserving all member data,
+     *             master assignment, and active character associations.
+     *
+     * @param[in]  g     The source group object to move from
      */
     group(group&& g);
 
     /**
-     * @brief      Destroys the object.
+     * @brief      Destroys the group and cleans up member associations.
+     *
+     *             Removes all active character associations and cleans up group
+     *             resources when the group object is destroyed.
      */
     ~group() = default;
 

--- a/include/fb/game/object.h
+++ b/include/fb/game/object.h
@@ -96,24 +96,35 @@ public:
 
 protected:
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Constructs a new game object with the specified context and model.
      *
-     * @param      context  The game context managing this object
-     * @param[in]  model    The object model data containing name, appearance, and other settings
-     * @param[in]  c        Initial parameters for object construction
+     *             Creates a new game object using the provided context for management,
+     *             model data for appearance and behavior, and initial parameters for
+     *             positioning and state setup.
+     *
+     * @param[in]  context  The game context that will manage this object's lifecycle
+     * @param[in]  model    The object model containing visual and behavioral data
+     * @param[in]  c        Initial parameters including position, direction, and other setup values
      */
     object(fb::game::context& context, const fb::model::object& model, const initial_params& c);
 
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Copy constructor for creating an object from another object.
      *
-     * @param[in]  right  The source object to copy from
+     *             Creates a new object by copying all properties and state from the
+     *             source object, including position, appearance, and internal data.
+     *
+     * @param[in]  right  The source object to copy all properties from
      */
     object(const object& right);
 
 public:
     /**
-     * @brief      Destroys the object.
+     * @brief      Destroys the game object and cleans up all resources.
+     *
+     *             Removes the object from its current map, notifies listeners,
+     *             cleans up any associated resources, and ensures proper cleanup
+     *             of all references and connections.
      */
     virtual ~object();
 

--- a/include/fb/mutex.h
+++ b/include/fb/mutex.h
@@ -52,16 +52,22 @@ private:
 
 public:
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Constructs a new mutex system for the specified context.
      *
-     * @param[in]  owner  The owner.
+     *             Creates a mutex management system that will handle named locks
+     *             and deadlock detection for the given context owner.
+     *
+     * @param[in]  owner  The context that owns and manages this mutex system
      */
     mutex(fb::context& owner) :
         _owner(owner)
     { }
 
     /**
-     * @brief      Destroys the mutex.
+     * @brief      Destroys the mutex system and releases all managed locks.
+     *
+     *             Cleans up the mutex pool and ensures all named mutexes are
+     *             properly released before destruction.
      */
     ~mutex() = default;
 

--- a/include/fb/stream.h
+++ b/include/fb/stream.h
@@ -14,40 +14,53 @@
 namespace fb {
 
 /**
- * @brief      This class describes a stream of bytes.
+ * @brief      Binary data stream with compression and checksum capabilities.
+ *
+ *             This class extends std::vector<uint8_t> to provide a convenient interface
+ *             for handling binary data streams. It includes built-in support for zlib
+ *             compression/decompression and CRC32 checksum calculation when available.
  */
 class stream : public std::vector<uint8_t>
 {
 public:
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Constructs an empty stream.
+     *
+     *             Creates a new stream with no initial data.
      */
     stream() = default;
 
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Constructs a stream from raw binary data.
      *
-     * @param[in]  data  The data to copy from.
-     * @param[in]  size  The size of the data.
+     *             Creates a new stream by copying the specified binary data.
+     *
+     * @param[in]  data  Pointer to the source data to copy
+     * @param[in]  size  Number of bytes to copy from the source data
      */
     stream(const uint8_t* data, size_t size);
 
     /**
-     * @brief      Constructs a new instance from a vector.
+     * @brief      Constructs a stream by moving data from a vector.
      *
-     * @param      v     The vector to move data from.
+     *             Creates a new stream by taking ownership of the data from
+     *             an existing vector, avoiding unnecessary copying.
+     *
+     * @param[in]  v     The vector to move data from
      */
     stream(std::vector<uint8_t>&& v);
 
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Copy constructor for creating a stream from another stream.
      *
-     * @param[in]  right  The right stream to copy from.
+     *             Creates a new stream by copying all data from the source stream.
+     *
+     * @param[in]  right  The source stream to copy from
      */
     stream(const stream& right);
 
     /**
-     * @brief      Destroys the object.
+     * @brief      Destroys the stream and releases its resources.
      */
     ~stream() = default;
 
@@ -55,21 +68,32 @@ public:
     /**
      * @brief      Calculates the CRC32 checksum of the stream data.
      *
-     * @return     The CRC32 checksum.
+     *             Computes a CRC32 checksum over all bytes in the stream,
+     *             useful for data integrity verification.
+     *
+     * @return     The CRC32 checksum value
      */
     uint32_t crc() const;
 
     /**
-     * @brief      Compresses the stream data using zlib.
+     * @brief      Compresses the stream data using zlib deflate algorithm.
      *
-     * @return     A new stream containing the compressed data.
+     *             Creates a new stream containing the compressed version of this
+     *             stream's data using zlib compression.
+     *
+     * @return     A new stream containing the compressed data
+     * @throws     std::runtime_error if compression fails
      */
     stream compress() const;
 
     /**
-     * @brief      Decompresses the stream data using zlib.
+     * @brief      Decompresses the stream data using zlib inflate algorithm.
      *
-     * @return     A new stream containing the decompressed data.
+     *             Creates a new stream containing the decompressed version of this
+     *             stream's data, assuming it was previously compressed with zlib.
+     *
+     * @return     A new stream containing the decompressed data
+     * @throws     std::runtime_error if decompression fails
      */
     stream decompress() const;
 #endif

--- a/include/fb/stream_reader.h
+++ b/include/fb/stream_reader.h
@@ -8,7 +8,11 @@
 namespace fb {
 
 /**
- * @brief      This class describes a stream reader.
+ * @brief      Binary stream reader with endian-aware data extraction capabilities.
+ *
+ *             This template class provides a convenient interface for reading binary data
+ *             from byte streams with automatic endian conversion. It supports reading
+ *             primitive types, strings with length prefixes, and raw binary data.
  *
  * @tparam     EndianType  The endian type for reading data (big_endian or little_endian).
  */
@@ -25,9 +29,12 @@ private:
 
 public:
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Constructs a new stream reader for the specified byte stream.
      *
-     * @param      stream  The stream to read from.
+     *             Creates a reader that will extract data from the given stream
+     *             starting at position 0. The reader maintains its own seek position.
+     *
+     * @param[in]  stream  The byte stream to read data from
      */
     stream_reader(std::vector<uint8_t>& stream) :
         _stream(stream)
@@ -37,9 +44,13 @@ public:
     /**
      * @brief      Reads a value of the specified type from the stream.
      *
-     * @tparam     ValueType  The type of value to read.
+     *             Extracts a value from the current seek position, automatically
+     *             handling endian conversion. For strings, uses uint8_t length prefix.
      *
-     * @return     The read value.
+     * @tparam     ValueType  The type of value to read from the stream
+     *
+     * @return     The value read from the stream with proper endian conversion
+     * @throws     std::runtime_error if not enough data is available
      */
     template <typename ValueType>
     ValueType read()
@@ -61,12 +72,17 @@ public:
     }
 
     /**
-     * @brief      Reads a string with length prefix from the stream.
+     * @brief      Reads a string with custom length prefix type from the stream.
      *
-     * @tparam     T1    The string type (must be std::string).
-     * @tparam     T2    The type of the length prefix.
+     *             Extracts a string by first reading a length prefix of the specified
+     *             type, then reading that many bytes as string data. Handles UTF-8
+     *             conversion on non-Windows platforms.
      *
-     * @return     The read string.
+     * @tparam     T1    The string type (must be std::string)
+     * @tparam     T2    The type of the length prefix (uint8_t, uint16_t, etc.)
+     *
+     * @return     The string read from the stream with proper encoding
+     * @throws     std::runtime_error if not enough data is available
      */
     template <typename T1, typename T2>
     T1 read()
@@ -94,10 +110,14 @@ public:
 
 public:
     /**
-     * @brief      Reads raw data into a buffer.
+     * @brief      Reads raw binary data into a provided buffer.
      *
-     * @param      buffer  The buffer to read data into.
-     * @param[in]  size    The number of bytes to read.
+     *             Copies the specified number of bytes from the current stream
+     *             position into the destination buffer. Advances the seek position.
+     *
+     * @param[out] buffer  The destination buffer to copy data into (can be nullptr to skip)
+     * @param[in]  size    The number of bytes to read from the stream
+     * @throws     std::runtime_error if not enough data is available
      */
     void read(void* buffer, size_t size)
     {
@@ -110,9 +130,12 @@ public:
     }
 
     /**
-     * @brief      Gets the number of bytes available for reading.
+     * @brief      Gets the number of bytes available for reading from current position.
      *
-     * @return     The number of readable bytes.
+     *             Calculates how many bytes remain in the stream from the current
+     *             seek position to the end of the stream.
+     *
+     * @return     The number of bytes that can still be read
      */
     uint32_t readable_size() const
     {
@@ -120,9 +143,9 @@ public:
     }
 
     /**
-     * @brief      Gets the current seek position.
+     * @brief      Gets the current read position in the stream.
      *
-     * @return     The current seek position.
+     * @return     The current seek position (offset from stream beginning)
      */
     uint32_t seek() const
     {
@@ -130,9 +153,12 @@ public:
     }
 
     /**
-     * @brief      Sets the seek position.
+     * @brief      Sets the read position in the stream.
      *
-     * @param[in]  value  The new seek position.
+     *             Moves the seek position to the specified offset from the
+     *             beginning of the stream for subsequent read operations.
+     *
+     * @param[in]  value  The new seek position (offset from stream beginning)
      */
     void seek(uint32_t value)
     {
@@ -140,7 +166,11 @@ public:
     }
 
     /**
-     * @brief      Flushes the stream.
+     * @brief      Removes processed data from the beginning of the stream.
+     *
+     *             Erases all bytes from the stream beginning up to the current
+     *             seek position, then resets the seek position to 0. This is
+     *             useful for freeing memory after processing data.
      */
     void flush()
     {
@@ -149,7 +179,10 @@ public:
     }
 
     /**
-     * @brief      Clears the stream.
+     * @brief      Clears all data from the stream and resets position.
+     *
+     *             Removes all bytes from the stream and resets the seek
+     *             position to 0, effectively starting with an empty stream.
      */
     void clear()
     {

--- a/include/fb/stream_writer.h
+++ b/include/fb/stream_writer.h
@@ -8,7 +8,11 @@
 namespace fb {
 
 /**
- * @brief      This class describes a stream writer.
+ * @brief      Binary stream writer with endian-aware data serialization capabilities.
+ *
+ *             This template class provides a convenient interface for writing binary data
+ *             to byte streams with automatic endian conversion. It supports writing
+ *             primitive types, strings with length prefixes, and raw binary data.
  *
  * @tparam     EndianType  The endian type for writing data (big_endian or little_endian).
  */
@@ -24,9 +28,12 @@ private:
 
 public:
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Constructs a new stream writer for the specified byte stream.
      *
-     * @param      stream  The stream to write data to.
+     *             Creates a writer that will append data to the given stream.
+     *             All write operations will add data to the end of the stream.
+     *
+     * @param[in]  stream  The byte stream to write data to
      */
     stream_writer(std::vector<uint8_t>& stream) :
         _stream(stream)
@@ -36,11 +43,15 @@ public:
     /**
      * @brief      Writes a value of the specified type to the stream.
      *
-     * @param[in]  value      The value to write.
+     *             Serializes the value to the end of the stream with proper endian
+     *             conversion. For strings, uses uint8_t length prefix. For fb::stream
+     *             objects, appends all bytes directly.
      *
-     * @tparam     ValueType  The type of value to write.
+     * @param[in]  value      The value to write to the stream
      *
-     * @return     Reference to this stream writer for chaining.
+     * @tparam     ValueType  The type of value to write to the stream
+     *
+     * @return     Reference to this stream writer for method chaining
      */
     template <typename ValueType>
     stream_writer& write(const ValueType& value)
@@ -68,12 +79,15 @@ public:
     }
 
     /**
-     * @brief      Writes raw data from a buffer to the stream.
+     * @brief      Writes raw binary data from a buffer to the stream.
      *
-     * @param[in]  buffer  The buffer containing data to write.
-     * @param[in]  size    The number of bytes to write.
+     *             Copies the specified number of bytes from the source buffer
+     *             directly to the end of the stream without any conversion.
      *
-     * @return     Reference to this stream writer for chaining.
+     * @param[in]  buffer  The source buffer containing data to write
+     * @param[in]  size    The number of bytes to write from the buffer
+     *
+     * @return     Reference to this stream writer for method chaining
      */
     stream_writer& write(const void* buffer, size_t size)
     {
@@ -82,14 +96,19 @@ public:
     }
 
     /**
-     * @brief      Writes a string with length prefix to the stream.
+     * @brief      Writes a string with custom length prefix type to the stream.
      *
-     * @param[in]  value  The string value to write.
+     *             Serializes a string by first writing a length prefix of the specified
+     *             type, then writing the string bytes. Handles CP949 encoding conversion
+     *             on non-Windows platforms.
      *
-     * @tparam     T1     The string type (must be std::string).
-     * @tparam     T2     The type of the length prefix.
+     * @param[in]  value  The string value to write to the stream
      *
-     * @return     Reference to this stream writer for chaining.
+     * @tparam     T1     The string type (must be std::string)
+     * @tparam     T2     The type of the length prefix (uint8_t, uint16_t, etc.)
+     *
+     * @return     Reference to this stream writer for method chaining
+     * @throws     std::runtime_error if T1 is not std::string
      */
     template <typename T1, typename T2>
     stream_writer& write(const T1& value)

--- a/include/fb/thread.h
+++ b/include/fb/thread.h
@@ -20,7 +20,12 @@ namespace fb {
 class thread_container;
 
 /**
- * @brief      This class describes a thread.
+ * @brief      Asynchronous execution thread with timer and task queue support.
+ *
+ *             This class provides a managed thread environment for executing asynchronous
+ *             tasks with built-in timer support, task queuing, and Lua integration.
+ *             Each thread maintains its own timer collection and task queue for
+ *             thread-safe asynchronous operations.
  */
 class thread : public fb::lua::luable
 {
@@ -51,13 +56,20 @@ private:
 
 public:
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Constructs a new thread with the specified index.
      *
-     * @param[in]  index  The index of the thread.
+     *             Creates and starts a new managed thread for asynchronous execution.
+     *             The thread will begin processing tasks and timers immediately.
+     *
+     * @param[in]  index  The unique identifier for this thread within the thread pool
      */
     thread(uint8_t index);
+
     /**
-     * @brief      Destroys the thread.
+     * @brief      Destroys the thread and waits for completion.
+     *
+     *             Signals the thread to exit, waits for all pending tasks to complete,
+     *             and cleans up all associated resources including timers and queued tasks.
      */
     ~thread();
 

--- a/include/fb/thread_switchable.h
+++ b/include/fb/thread_switchable.h
@@ -7,12 +7,16 @@
 namespace fb {
 
 /**
- * @brief      This class describes a thread.
+ * @brief      Forward declaration of the thread class.
  */
 class thread;
 
 /**
- * @brief      This class describes a thread switchable.
+ * @brief      Base class for objects that can be associated with and switched between threads.
+ *
+ *             This class provides a foundation for objects that need to be aware of which
+ *             thread they belong to and can validate thread affinity. It integrates with
+ *             the Lua scripting system and provides thread safety assertions.
  */
 class thread_switchable : public lua::luable
 {
@@ -21,40 +25,57 @@ public:
 
 protected:
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Constructs a new thread-switchable object with no thread association.
+     *
+     *             Creates an object that can be associated with threads but starts
+     *             without any specific thread assignment.
      */
     thread_switchable() = default;
 
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Constructs a new thread-switchable object with thread ID.
      *
-     * @param[in]  id    The ID of the thread.
+     *             Creates an object associated with a specific thread identified
+     *             by the given ID for thread affinity tracking.
+     *
+     * @param[in]  id    The identifier of the thread to associate with this object
      */
     thread_switchable(uint32_t id);
 
 public:
     /**
-     * @brief      Destroys the thread switchable.
+     * @brief      Destroys the thread-switchable object and cleans up thread associations.
      */
     virtual ~thread_switchable() = default;
 
 public:
     /**
-     * @brief      Gets the thread associated with this thread switchable.
+     * @brief      Gets the thread associated with this thread-switchable object.
      *
-     * @return     A pointer to the associated thread.
+     *             Returns a pointer to the thread that this object is currently
+     *             associated with for execution and thread safety validation.
+     *
+     * @return     A pointer to the associated thread, or nullptr if not associated
      */
     virtual fb::thread* thread() const = 0;
 
     /**
-     * @brief      Asserts that the current thread matches the thread switchable's thread.
+     * @brief      Asserts that the current executing thread matches this object's thread.
+     *
+     *             Validates that the currently executing thread is the same as the
+     *             thread associated with this object. Throws an exception if they don't match.
+     *
+     * @throws     std::runtime_error if the current thread doesn't match the associated thread
      */
     virtual void assert_thread() const;
 
     /**
-     * @brief      Checks if the current thread matches the thread switchable's thread.
+     * @brief      Checks if the current executing thread matches this object's thread.
      *
-     * @return     True if the threads match, false otherwise.
+     *             Performs a non-throwing check to determine if the currently executing
+     *             thread is the same as the thread associated with this object.
+     *
+     * @return     True if the current thread matches the associated thread, false otherwise
      */
     virtual bool matched_thread() const;
 };

--- a/include/fb/timer.h
+++ b/include/fb/timer.h
@@ -14,7 +14,12 @@ namespace fb {
 class thread;
 
 /**
- * @brief      This class describes a timer.
+ * @brief      High-precision timer for scheduling asynchronous callbacks.
+ *
+ *             This class provides a timer mechanism that can execute callback functions
+ *             at specified intervals or after a delay. Timers can be configured as
+ *             disposable (one-shot) or repeating, and integrate with the thread system
+ *             for asynchronous execution.
  */
 class timer
 {
@@ -23,55 +28,67 @@ public:
 
 public:
     /**
-     * @brief      The type of the callback function.
+     * @brief      Callback function type for timer events.
+     *
+     *             The callback receives the current datetime and the thread ID
+     *             where the timer is executing.
      */
     using handle_callback_type = std::function<async::task<void>(const fb::model::datetime&, std::thread::id)>;
 
 public:
-    const handle_callback_type fn;
-    const fb::model::timespan  duration;
-    const bool                 disposable = false;
-    fb::model::datetime        begin;
+    const handle_callback_type fn;                 ///< The callback function to execute
+    const fb::model::timespan  duration;           ///< The timer interval or delay
+    const bool                 disposable = false; ///< Whether this is a one-shot timer
+    fb::model::datetime        begin;              ///< The start time of the timer
 
 private:
     /**
-     * @brief      Constructs a new instance.
+     * @brief      Constructs a new timer with the specified parameters.
      *
-     * @param[in]  fn        The callback function.
-     * @param[in]  duration  The duration of the timer.
-     * @param[in]  disposable  Whether the timer is disposable.
+     *             Creates a timer that will execute the given callback function
+     *             after the specified duration. The timer can be configured as
+     *             disposable (executes once) or repeating.
+     *
+     * @param[in]  fn          The callback function to execute when the timer fires
+     * @param[in]  duration    The time interval for the timer
+     * @param[in]  disposable  If true, the timer executes once and is destroyed
      */
     timer(const handle_callback_type& fn, const fb::model::timespan& duration, bool disposable);
+
     /**
      * @brief      Copy constructor (deleted).
      *
-     * @param[in]  other  The other timer to copy from.
+     *             Timers cannot be copied to prevent resource management issues.
      */
     timer(const timer&) = delete;
+
     /**
      * @brief      Move constructor (deleted).
      *
-     * @param[in]  other  The other timer to move from.
+     *             Timers cannot be moved to maintain thread safety and resource integrity.
      */
     timer(timer&&) = delete;
 
     /**
-     * @brief      Assignment operator (deleted).
+     * @brief      Copy assignment operator (deleted).
      *
-     * @param[in]  other  The other timer to copy from.
+     *             Timers cannot be assigned to prevent resource management issues.
      */
     timer& operator= (timer&) = delete;
 
     /**
-     * @brief      Assignment operator (deleted).
+     * @brief      Copy assignment operator (deleted).
      *
-     * @param[in]  other  The other timer to copy from.
+     *             Timers cannot be assigned to prevent resource management issues.
      */
     timer& operator= (const timer&) = delete;
 
 public:
     /**
-     * @brief      Destroys the timer.
+     * @brief      Destroys the timer and cleans up resources.
+     *
+     *             Ensures proper cleanup of timer resources when the timer
+     *             is destroyed or goes out of scope.
      */
     ~timer()
     { }


### PR DESCRIPTION
- Replace generic comments with specific, meaningful descriptions

- Fix 'This class describes' to detailed class purpose and capabilities

- Fix 'Constructs a new instance' to specific constructor behavior

- Fix 'Destroys the object' to actual cleanup and resource management

- Maintain proper indentation and @param[in] format consistency

- Enhanced documentation for core classes: concurrent, timer, stream, thread, mutex

- Enhanced documentation for game classes: object, clan, group

- Enhanced documentation for utility classes: stream_reader, stream_writer, thread_switchable