### PR TITLE
fix: remove duplicate on_hook_position hook from skill test

### DIFF
--- a/bot/lib/game_bot.cpp
+++ b/bot/lib/game_bot.cpp
@@ -54,6 +54,7 @@ point<uint16_t> game_bot::position() const
 void game_bot::set_position(const point<uint16_t>& value)
 {
     this->_position = value;
+    fb::logger::info("Bot {} position set to ({}, {})", this->_oid, value.x, value.y);
 }
 
 bool game_bot::is_initialized() const
@@ -423,6 +424,38 @@ const std::string& game_bot::name() const
 void game_bot::set_name(const std::string& value)
 {
     this->_name = value;
+}
+
+async::task<void> game_bot::move(DIRECTION direction, int step, const fb::model::timespan& delay)
+{
+    auto thread = this->thread();
+    auto before = this->_position;
+    auto after  = before;
+    for (int i = 0; i < step; i++)
+    {
+        this->send(fb::protocol::game::request::move{direction, this->_oid, after});
+        switch (direction)
+        {
+        case DIRECTION::LEFT:
+            after.x--;
+            break;
+
+        case DIRECTION::TOP:
+            after.y--;
+            break;
+
+        case DIRECTION::RIGHT:
+            after.x++;
+            break;
+
+        case DIRECTION::BOTTOM:
+            after.y++;
+            break;
+        }
+
+        this->_position = after;
+        co_await this->thread()->sleep(delay);
+    }
 }
 
 async::task<void> game_bot::process_random_pattern(const fb::model::datetime& now)

--- a/bot/lib/integration/game_controller.cpp
+++ b/bot/lib/integration/game_controller.cpp
@@ -29,146 +29,83 @@ void game_bot_controller::initialize()
     // Set up integration test timer with different interval (slower for detailed testing)
     this->bind_timer(&game_bot_controller::handle_timer, 1000ms);
 
-    // Initialize test queue with sequence of tests
-    // this->_test_queue.push(std::make_unique<movement_test>());
-    // this->_test_queue.push(std::make_unique<attack_test>());
-    this->_test_queue.push(std::make_unique<skill_test>());
-
-    // Start the first test
-    this->start_next_test();
+    // Create tests and add them to the queue
+    this->enqueue_test(std::make_unique<movement_test>(*this));
+    this->enqueue_test(std::make_unique<attack_test>(*this));
+    this->enqueue_test(std::make_unique<skill_test>(*this));
 
     fb::logger::info("Integration test controller initialized with test queue (movement -> attack -> skill)");
+
+    // Activate the first test
+    std::ignore = this->activate_first_test();
 }
 
-async::task<void> game_bot_controller::set_test(std::unique_ptr<bot_integration_test> test)
+async::task<void> game_bot_controller::activate_first_test()
 {
-    co_await this->_current_test.async_write([&](auto& current_test) -> async::task<void> {
-        if (current_test)
-        {
-            if (current_test->is_running())
-            {
-                fb::logger::warn("Stopping current test '{}' to set new test", current_test->name());
-            }
-
-            // Cleanup previous test bots
-            current_test->cleanup();
-        }
-
-        current_test = std::move(test);
-
-        if (current_test)
-        {
-            current_test->reset();
-            fb::logger::info("Test case set to: {}", current_test->name());
-            co_await current_test->initialize(*this);
-            fb::logger::info("Test '{}' initialization completed", current_test->name());
-            co_return;
-        }
-    });
-}
-
-async::task<bool> game_bot_controller::start_test()
-{
-    // Step 1: 짧은 락으로 실행 가능성 판단 + 테스트 참조 복사
-    bot_integration_test* test_to_run = nullptr;
-    std::string           test_name;
-
-    bool can_start = this->_current_test.write([&](auto& current_test) -> bool {
-        if (!current_test)
-        {
-            fb::logger::warn("No test case is currently set");
-            return false;
-        }
-
-        if (current_test->is_running())
-        {
-            fb::logger::warn("Test '{}' is already running", current_test->name());
-            return false;
-        }
-
-        if (current_test->is_complete())
-        {
-            fb::logger::info("Resetting completed test '{}'", current_test->name());
-            current_test->reset();
-        }
-
-        test_name   = current_test->name();
-        test_to_run = current_test.get(); // raw pointer 복사
-        return true;
-    });
-
-    if (!can_start)
-        co_return false;
-
-    // Step 2: 락 없이 테스트 실행
-    fb::logger::info("Starting test '{}'", test_name);
-    auto result = co_await test_to_run->execute();
-
-    co_return result;
-}
-
-void game_bot_controller::reset_current_test()
-{
-    this->_current_test.write([](auto& current_test) {
-        if (current_test)
-        {
-            current_test->reset();
-            fb::logger::info("Test '{}' has been reset", current_test->name());
-        }
-    });
-}
-
-async::task<void> game_bot_controller::start_next_test()
-{
-    if (this->_test_queue.empty())
+    if (this->_current_test == nullptr)
     {
-        fb::logger::info("All integration tests completed successfully!");
+        fb::logger::warn("No tests to activate");
         co_return;
     }
 
-    // Get next test from queue
-    auto next_test = std::move(this->_test_queue.front());
-    this->_test_queue.pop();
+    fb::logger::info("Activating first test: '{}'", this->_current_test->name());
 
-    // Set as current test (this will also initialize it)
-    co_await this->set_test(std::move(next_test));
+    // Initialize the test (creates bots, etc.)
+    co_await this->_current_test->initialize(*this);
+
+    fb::logger::info("Test '{}' activated and ready to receive bot connections", this->_current_test->name());
+}
+
+void game_bot_controller::notify_test_completed(bot_integration_test* test)
+{
+    if (this->_current_test == test)
+    {
+        fb::logger::info("Test '{}' completed", test->name());
+        this->_current_test = nullptr;
+
+        // Start the next test in the queue
+        this->start_next_test();
+    }
+}
+
+void game_bot_controller::notify_test_ready()
+{
+    if (this->_current_test)
+    {
+        fb::logger::info("Test '{}' is ready, starting execution", this->_current_test->name());
+        std::ignore = this->start_current_test();
+    }
+}
+
+async::task<void> game_bot_controller::start_current_test()
+{
+    if (!this->_current_test)
+    {
+        fb::logger::warn("No current test to start");
+        co_return;
+    }
+
+    if (this->_current_test->is_running())
+    {
+        fb::logger::warn("Test '{}' is already running", this->_current_test->name());
+        co_return;
+    }
+
+    fb::logger::info("Starting test '{}'", this->_current_test->name());
+    std::ignore = co_await this->_current_test->execute();
 }
 
 async::task<void> game_bot_controller::handle_timer()
 {
-    bool        should_start = false;
-    std::string test_name;
+    // Timer is only used for starting the first test from the queue
+    // Subsequent tests are started automatically by the test chain
+    static bool first_test_started = false;
 
-    // Check test state with minimal lock time to avoid deadlock
-    this->_current_test.read([&](const auto& current_test) {
-        if (!current_test)
-            return;
-
-        test_name    = current_test->name();
-        should_start = !current_test->is_running() && !current_test->is_complete() && current_test->is_ready();
-    });
-
-    // Handle test start (outside of lock to avoid deadlock)
-    if (should_start)
+    if (!first_test_started)
     {
-        fb::logger::info("All bots are ready for '{}', starting test", test_name);
-        try
-        {
-            auto success = co_await this->start_test();
-            if (success)
-            {
-                fb::logger::info("Test '{}' completed successfully, starting next test", test_name);
-                co_await this->start_next_test();
-            }
-            else
-            {
-                fb::logger::fatal("Test '{}' failed, stopping test sequence", test_name);
-            }
-        }
-        catch (std::exception& e)
-        {
-            fb::logger::warn("Failed to execute test '{}': {}", test_name, e.what());
-        }
+        first_test_started = true;
+        // No longer need to start tests - they start automatically via hooks
+        fb::logger::info("Integration test controller initialized - tests will start automatically");
     }
 
     co_return;
@@ -205,6 +142,7 @@ async::task<void> game_bot_controller::handle_sequence(game_bot& bot, const fb::
 {
     // Integration test: Validate object ID consistency
     bot.set_oid(response.oid);
+
     co_return;
 }
 
@@ -258,26 +196,26 @@ async::task<void> game_bot_controller::handle_transfer(game_bot& bot, const fb::
 
 async::task<void> game_bot_controller::on_bot_connected(game_bot& bot)
 {
-    // Notify current test about bot connection
-    this->_current_test.read([this, &bot](const auto& current_test) {
-        if (current_test)
-        {
-            // Use shared_from_this to get shared_ptr to game_bot
-            auto bot_shared = this->_bots.read([&bot](const auto& bots) {
-                auto it = bots.find(bot.id);
-                return (it != bots.end()) ? it->second : nullptr;
-            });
-
-            if (bot_shared)
-            {
-                // Let each test decide whether to store this bot or not
-                current_test->on_bot_connected(bot_shared);
-                fb::logger::debug("Game bot {} connection notified to test '{}'", bot.id, current_test->name());
-            }
-        }
-    });
-
     fb::logger::info("Bot {} connected for integration testing", bot.fd());
+
+    // Notify current test about bot connection
+    if (this->_current_test)
+    {
+        // Use shared_from_this to get shared_ptr to game_bot
+        auto bot_shared = this->_bots.read([&bot](const auto& bots) {
+            auto it = bots.find(bot.id);
+            return (it != bots.end()) ? it->second : nullptr;
+        });
+
+        if (bot_shared)
+        {
+            // Let the current test decide whether to store this bot or not
+            this->_current_test->on_bot_connected(bot_shared);
+            fb::logger::debug("Game bot {} connection notified to current test '{}'",
+                              bot.id,
+                              this->_current_test->name());
+        }
+    }
 
     // Integration test: Initialize test scenarios upon connection
     bot.send(fb::protocol::game::request::login(bot.transfer_buffer()), false, true);
@@ -292,4 +230,77 @@ async::task<void> game_bot_controller::on_bot_disconnected(game_bot& bot)
     // Integration test: Collect test results and perform cleanup
     // TODO: Generate test report for this bot session
     co_return;
+}
+
+async::task<void> game_bot_controller::on_integration_hook_execution(uint8_t                     cmd,
+                                                                     game_bot&                   bot,
+                                                                     const fb::protocol::header& header)
+{
+    // Only execute hooks if there's a current test
+    if (!this->_current_test)
+        co_return;
+
+    auto shared_lock = std::shared_lock<std::shared_mutex>(this->_hook_mutex);
+
+    // Execute hooks only for the current test
+    auto test_it = this->_test_hooks.find(this->_current_test);
+    if (test_it != this->_test_hooks.end())
+    {
+        auto& test_hooks = test_it->second;
+        auto  cmd_it     = test_hooks.find(cmd);
+        if (cmd_it != test_hooks.end())
+        {
+            for (auto& hook : cmd_it->second)
+            {
+                co_await hook(bot, header);
+            }
+        }
+    }
+}
+
+void game_bot_controller::enqueue_test(std::unique_ptr<bot_integration_test> test)
+{
+    // Store the test instance for lifetime management
+    this->_test_instances.push_back(std::move(test));
+
+    // Add the test to the queue
+    this->_test_queue.push(this->_test_instances.back().get());
+
+    // If this is the first test, set it as current
+    if (this->_current_test == nullptr)
+    {
+        this->_current_test = this->_test_queue.front();
+    }
+
+    fb::logger::debug("Test '{}' added to queue", this->_test_instances.back()->name());
+}
+
+void game_bot_controller::start_next_test()
+{
+    if (this->_test_queue.empty())
+    {
+        fb::logger::info("No more tests in queue");
+        return;
+    }
+
+    // Remove the completed test from the queue
+    this->_test_queue.pop();
+
+    if (this->_test_queue.empty())
+    {
+        fb::logger::info("All tests completed");
+        return;
+    }
+
+    // Set the next test as current
+    this->_current_test = this->_test_queue.front();
+    fb::logger::info("Starting next test: '{}'", this->_current_test->name());
+
+    // Activate the next test
+    std::ignore = this->activate_first_test();
+}
+
+bool game_bot_controller::has_more_tests() const
+{
+    return !this->_test_queue.empty();
 }

--- a/bot/lib/integration/test/attack_test.cpp
+++ b/bot/lib/integration/test/attack_test.cpp
@@ -2,12 +2,20 @@
 #include <fb/bot/integration/game_controller.h>
 #include <fb/bot/integration/gateway_controller.h>
 #include <fb/logger.h>
-#include <fb/game/protocol/attack.h>
+#include <fb/game/protocol.h>
 #include <chrono>
 
 using namespace std::chrono_literals;
 
 namespace fb::bot::integration {
+
+attack_test::attack_test(game_bot_controller& controller) :
+    bot_integration_test(controller)
+{
+    // Register hook for object ID (sequence) responses
+    this->_controller.hook_external(this, this, &attack_test::on_hook_sequence);
+    fb::logger::debug("Attack test constructed");
+}
 
 async::task<void> attack_test::initialize(game_bot_controller& controller)
 {
@@ -19,13 +27,25 @@ async::task<void> attack_test::initialize(game_bot_controller& controller)
 
     fb::logger::info("Attack test initializing and spawning {} bot", REQUIRED_BOTS);
 
-    for (auto i = 0; i < REQUIRED_BOTS; i++)
-    {
-        auto gateway_bot = controller.container.gateway->create();
-        gateway_bot->connect(endpoint);
-    }
+    auto gateway_bot = controller.container.gateway->create();
+    gateway_bot->connect(endpoint);
 
     fb::logger::info("Attack test initialization completed - {} bot spawned", REQUIRED_BOTS);
+    co_return;
+}
+
+async::task<void> attack_test::on_hook_sequence(fb::bot::game_bot&                      bot,
+                                                const fb::protocol::game::response::id& response)
+{
+    if (this->is_ready() == false)
+        co_return;
+
+    if (this->get_state() == test_state::running)
+        co_return;
+
+    fb::logger::info("Attack test: All bots ready, notifying controller");
+    this->set_state(test_state::ready);
+    this->notify_ready();
     co_return;
 }
 
@@ -33,68 +53,66 @@ async::task<bool> attack_test::execute()
 {
     constexpr auto interval = 100ms;
 
-    if (this->_test_running || this->_test_completed)
+    if (this->get_state() == test_state::running || this->get_state() == test_state::completed)
         co_return false;
 
-    this->_test_running = true;
+    this->set_state(test_state::running);
 
     auto bots = this->get_test_bots();
-    fb::logger::info("Starting attack test with {} bot", bots.size());
+    fb::logger::info("Starting attack test with {} bots", bots.size());
 
     if (bots.empty())
     {
         fb::logger::fatal("No bots available for attack test");
-        this->_test_running = false;
+        this->set_state(test_state::failed);
         co_return false;
     }
 
-    // Use the first (and only) bot for attacks
-    auto target_bot = bots.front();
+    auto target_bot = bots[0];
 
-    fb::logger::info("Bot {} performing {} attacks", target_bot->fd(), ATTACK_COUNT);
+    fb::logger::info("Attack test: Bot {} will perform attack sequences", target_bot->fd());
 
-    // Perform attack sequences
+    // Perform attack sequences - simple attack to air 5 times
+    constexpr int ATTACK_COUNT = 5;
     for (auto i = 0; i < ATTACK_COUNT; i++)
     {
-        // Send attack packet
         target_bot->send(fb::protocol::game::request::attack{});
 
-        fb::logger::debug("Attack {}: bot {} performed attack", i + 1, target_bot->fd());
+        fb::logger::debug("Attack sequence {}: bot {} performed attack", i + 1, target_bot->fd());
 
         auto thread = target_bot->thread();
         co_await thread->switching();
         co_await thread->sleep(interval);
     }
 
-    this->_test_completed = true;
-    this->_test_running   = false;
+    this->set_state(test_state::completed);
 
-    fb::logger::info("Attack test completed successfully - {} attacks performed", ATTACK_COUNT);
+    fb::logger::info("Attack test completed successfully");
 
     // Cleanup bots after test completion
     this->cleanup();
+
+    // Notify controller that this test is completed
+    this->_controller.notify_test_completed(this);
 
     co_return true; // 성공
 }
 
 void attack_test::reset()
 {
-    this->_test_completed = false;
-    this->_test_running   = false;
-
+    this->set_state(test_state::idle);
     fb::logger::info("Attack test reset");
 }
 
 bool attack_test::is_ready() const
 {
-    auto bots = this->get_test_bots();
-    if (bots.empty())
+    if (this->get_test_bots().empty())
         return false;
 
     // Movement test requires all bots to have non-zero oid
-    for (const auto& bot : bots)
+    for (const auto& bot : this->get_test_bots())
     {
-        if (bot->oid() == 0)
+        if (bot->oid() == 0 && bot->oid() != 0xFFFFFFFD)
             return false;
     }
 
@@ -103,25 +121,20 @@ bool attack_test::is_ready() const
 
 void attack_test::on_bot_connected(std::shared_ptr<fb::bot::game_bot> bot)
 {
-    this->_test_bots.push_back(bot);
+    bot_integration_test::on_bot_connected(bot);
     fb::logger::debug("Attack test: Bot {} added to collection", bot->fd());
-}
-
-std::vector<std::shared_ptr<fb::bot::game_bot>> attack_test::get_test_bots() const
-{
-    return this->_test_bots;
 }
 
 void attack_test::cleanup()
 {
-    for (auto bot : this->_test_bots)
+    auto bots = this->get_test_bots();
+    for (auto bot : bots)
     {
         if (bot)
         {
             bot->close();
         }
     }
-    this->_test_bots.clear();
 
     fb::logger::info("Attack test cleanup completed - all bots disconnected");
 }

--- a/bot/lib/integration/test/movement_test.cpp
+++ b/bot/lib/integration/test/movement_test.cpp
@@ -10,6 +10,14 @@ using namespace std::chrono_literals;
 
 namespace fb::bot::integration {
 
+movement_test::movement_test(game_bot_controller& controller) :
+    bot_integration_test(controller)
+{
+    // Register hook for object ID (sequence) responses
+    this->_controller.hook_external(this, this, &movement_test::on_hook_sequence);
+    fb::logger::debug("Movement test constructed");
+}
+
 async::task<void> movement_test::initialize(game_bot_controller& controller)
 {
     constexpr auto REQUIRED_BOTS = 5;
@@ -30,14 +38,31 @@ async::task<void> movement_test::initialize(game_bot_controller& controller)
     co_return;
 }
 
+async::task<void> movement_test::on_hook_sequence(fb::bot::game_bot&                      bot,
+                                                  const fb::protocol::game::response::id& response)
+{
+    fb::logger::debug("Movement test: Bot {} received object ID {}", bot.fd(), response.oid);
+
+    if (this->is_ready() == false)
+        co_return;
+
+    if (this->get_state() == test_state::running)
+        co_return;
+
+    fb::logger::info("Movement test: All bots ready, notifying controller");
+    this->set_state(test_state::ready);
+    this->notify_ready();
+    co_return;
+}
+
 async::task<bool> movement_test::execute()
 {
     constexpr auto interval = 100ms;
 
-    if (this->_test_running || this->_test_completed)
+    if (this->get_state() == test_state::running || this->get_state() == test_state::completed)
         co_return false;
 
-    this->_test_running = true;
+    this->set_state(test_state::running);
 
     auto bots = this->get_test_bots();
     fb::logger::info("Starting movement test with {} bots", bots.size());
@@ -45,7 +70,7 @@ async::task<bool> movement_test::execute()
     if (bots.empty())
     {
         fb::logger::fatal("No bots available for movement test");
-        this->_test_running = false;
+        this->set_state(test_state::failed);
         co_return false;
     }
 
@@ -76,37 +101,35 @@ async::task<bool> movement_test::execute()
         co_await thread->sleep(interval);
     }
 
-    this->_test_completed = true;
-    this->_test_running   = false;
+    this->set_state(test_state::completed);
 
     fb::logger::info("Movement test completed successfully");
 
     // Cleanup bots after test completion
     this->cleanup();
 
+    // Notify controller that this test is completed
+    this->_controller.notify_test_completed(this);
+
     co_return true; // 성공
 }
 
 void movement_test::reset()
 {
-    this->_test_started   = false;
-    this->_test_completed = false;
-    this->_test_running   = false;
+    this->_state = test_state::idle;
 
     fb::logger::info("Movement test reset");
 }
 
 bool movement_test::is_ready() const
 {
-    auto bots = this->get_test_bots();
-
-    if (bots.empty())
+    if (this->get_test_bots().empty())
         return false;
 
     // Movement test requires all bots to have non-zero oid
-    for (const auto& bot : bots)
+    for (const auto& bot : this->get_test_bots())
     {
-        if (bot->oid() == 0)
+        if (bot->oid() == 0 && bot->oid() != 0xFFFFFFFD)
             return false;
     }
 
@@ -115,25 +138,20 @@ bool movement_test::is_ready() const
 
 void movement_test::on_bot_connected(std::shared_ptr<fb::bot::game_bot> bot)
 {
-    this->_test_bots.push_back(bot);
+    bot_integration_test::on_bot_connected(bot);
     fb::logger::debug("Movement test: Bot {} added to collection", bot->fd());
-}
-
-std::vector<std::shared_ptr<fb::bot::game_bot>> movement_test::get_test_bots() const
-{
-    return this->_test_bots;
 }
 
 void movement_test::cleanup()
 {
-    for (auto bot : this->_test_bots)
+    auto bots = this->get_test_bots();
+    for (auto bot : bots)
     {
         if (bot)
         {
             bot->close();
         }
     }
-    this->_test_bots.clear();
 
     fb::logger::info("Movement test cleanup completed - all bots disconnected");
 }

--- a/bot/lib/integration/test/skill_test.cpp
+++ b/bot/lib/integration/test/skill_test.cpp
@@ -13,6 +13,19 @@ using namespace std::chrono_literals;
 
 namespace fb::bot::integration {
 
+skill_test::skill_test(game_bot_controller& controller) :
+    bot_integration_test(controller)
+{
+    // Register hook for object ID (sequence) responses
+    this->_controller.hook_external(this, this, &skill_test::on_hook_sequence);
+    this->_controller.hook_external(this, this, &skill_test::on_hook_position);
+
+    // Initialize test function queue
+    this->initialize_test_functions();
+
+    fb::logger::debug("Skill test constructed");
+}
+
 async::task<void> skill_test::initialize(game_bot_controller& controller)
 {
     constexpr auto REQUIRED_BOTS = 5;
@@ -39,12 +52,12 @@ async::task<void> skill_test::initialize(game_bot_controller& controller)
 async::task<bool> skill_test::execute()
 {
     constexpr auto interval = 100ms; // Increased from 100ms to reduce server load
-    constexpr auto timeout  = 1h;    // Increased from 5s to handle server processing delays
+    constexpr auto timeout  = 5s;    // Increased from 5s to handle server processing delays
 
-    if (this->_test_running || this->_test_completed)
+    if (this->get_state() == test_state::running || this->get_state() == test_state::completed)
         co_return false;
 
-    this->_test_running = true;
+    this->set_state(test_state::running);
 
     auto bots = this->get_test_bots();
     fb::logger::info("Starting skill test with {} bot", bots.size());
@@ -52,7 +65,7 @@ async::task<bool> skill_test::execute()
     if (bots.empty())
     {
         fb::logger::fatal("No bots available for skill test");
-        this->_test_running = false;
+        this->set_state(test_state::failed);
         co_return false;
     }
 
@@ -62,22 +75,14 @@ async::task<bool> skill_test::execute()
     // Move bots in reverse order to avoid blocking (4→3→2→1)
     for (int i = static_cast<int>(bots.size()) - 1; i >= 1; --i)
     {
-        auto bot              = bots[i];
-        auto current_position = bot->position();
-        auto target_position  = current_position;
-        auto thread           = bot->thread();
+        auto& bot              = bots[i];
+        auto  current_position = bot->position();
+        auto  target_position  = current_position;
+        auto  thread           = bot->thread();
 
         // Move bot i steps to the right
         co_await thread->switching();
-        for (int step = 0; step < i; ++step)
-        {
-            target_position.x += 1;
-            bot->send(fb::protocol::game::request::move{DIRECTION::RIGHT, bot->oid(), bot->position()});
-            bot->set_position(target_position);
-
-            // Small delay between moves
-            co_await thread->sleep(50ms);
-        }
+        co_await bot->move(DIRECTION::RIGHT, i, 50ms);
 
         // Set direction to BOTTOM
         bot->send(fb::protocol::game::request::direction{DIRECTION::BOTTOM});
@@ -99,29 +104,21 @@ async::task<bool> skill_test::execute()
         co_return false;
     }
 
-    this->_test_completed = true;
-    this->_test_running   = false;
+    this->set_state(test_state::completed);
 
-    if (test_result)
-    {
-        fb::logger::info("Skill test completed successfully");
-        auto caster = bots.at(0);
-        caster->send(fb::protocol::game::request::chat(false, "=== SKILL TEST COMPLETED SUCCESSFULLY ==="));
-        this->cleanup();
-        co_return true;
-    }
-    else
-    {
-        fb::logger::fatal("Skill test failed");
-        auto caster = bots.at(0);
-        caster->send(fb::protocol::game::request::chat(false, "=== SKILL TEST FAILED ==="));
-        this->cleanup();
-        co_return false;
-    }
+    fb::logger::info("Skill test completed successfully");
+
+    // Cleanup bots after test completion
+    this->cleanup();
+
+    // Notify controller that this test is completed
+    this->_controller.notify_test_completed(this);
+
+    co_return true; // 성공
 }
 
-async::task<bool> skill_test::test_healing_spells(const std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
-                                                  std::chrono::milliseconds                              timeout)
+async::task<bool> skill_test::test_healing_spells(std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
+                                                  std::chrono::milliseconds                        timeout)
 {
     constexpr auto interval = 100ms;
 
@@ -137,7 +134,10 @@ async::task<bool> skill_test::test_healing_spells(const std::vector<std::shared_
     co_await thread->switching();
 
     // Setup all bots with max HP/MP and current HP
-    std::ignore = co_await this->setup_bots_hp_mp(bots, 100000, 100000, 50, std::nullopt, timeout);
+    for (auto& bot : bots)
+    {
+        std::ignore = co_await this->setup_bot_stats(bot, 100000, 100000, 50, std::nullopt, timeout);
+    }
 
     caster->send(fb::protocol::game::request::chat(false, "Bot setup completed - ready for spell testing"));
 
@@ -474,8 +474,8 @@ async::task<bool> skill_test::test_healing_spells(const std::vector<std::shared_
     co_return true;
 }
 
-async::task<bool> skill_test::test_damage_spells(const std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
-                                                 std::chrono::milliseconds                              timeout)
+async::task<bool> skill_test::test_damage_spells(std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
+                                                 std::chrono::milliseconds                        timeout)
 {
     constexpr auto interval = 100ms;
 
@@ -491,7 +491,10 @@ async::task<bool> skill_test::test_damage_spells(const std::vector<std::shared_p
     co_await thread->switching();
 
     // Setup all bots with max HP/MP
-    std::ignore = co_await this->setup_bots_hp_mp(bots, 100000, 100000, std::nullopt, std::nullopt, timeout);
+    for (auto& bot : bots)
+    {
+        std::ignore = co_await this->setup_bot_stats(bot, 100000, 100000, std::nullopt, std::nullopt, timeout);
+    }
 
     std::vector<damage_spell_test> damage_spells = {
         {"뢰진주",       SPELL_TYPE::TARGET, 320,  120},
@@ -572,8 +575,8 @@ async::task<bool> skill_test::test_damage_spells(const std::vector<std::shared_p
     co_return true;
 }
 
-async::task<bool> skill_test::test_near_damage_spells(const std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
-                                                      std::chrono::milliseconds                              timeout)
+async::task<bool> skill_test::test_near_damage_spells(std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
+                                                      std::chrono::milliseconds                        timeout)
 {
     constexpr auto interval = 100ms;
 
@@ -587,25 +590,14 @@ async::task<bool> skill_test::test_near_damage_spells(const std::vector<std::sha
     co_await thread->switching();
 
     // Step 1: Move caster down by 1 tile
-    auto original_position  = caster->position();
-    auto target_position    = original_position;
-    target_position.y      += 1;
-
-    caster->send(fb::protocol::game::request::move{DIRECTION::BOTTOM, caster->oid(), original_position});
-    caster->set_position(target_position);
-
-    fb::logger::info("Caster moved from ({}, {}) to ({}, {})",
-                     original_position.x,
-                     original_position.y,
-                     target_position.x,
-                     target_position.y);
-
+    co_await caster->move(DIRECTION::BOTTOM);
     co_await caster->thread()->sleep(100ms);
 
     // Step 2: Spawn 4 monsters around the caster
-    auto spawn_points  = std::vector<fb::model::point<uint16_t>>();
-    auto left_pos      = target_position;
-    left_pos.x        -= 1;
+    auto spawn_points     = std::vector<fb::model::point<uint16_t>>();
+    auto target_position  = caster->position();
+    auto left_pos         = target_position;
+    left_pos.x           -= 1;
     spawn_points.push_back(left_pos);
 
     auto top_pos  = target_position;
@@ -621,7 +613,10 @@ async::task<bool> skill_test::test_near_damage_spells(const std::vector<std::sha
     spawn_points.push_back(bottom_pos);
 
     // Setup all bots with max HP/MP
-    std::ignore = co_await this->setup_bots_hp_mp(bots, 100000, 100000, std::nullopt, std::nullopt, timeout);
+    for (auto& bot : bots)
+    {
+        std::ignore = co_await this->setup_bot_stats(bot, 100000, 100000, std::nullopt, std::nullopt, timeout);
+    }
 
     std::vector<near_damage_spell_test> near_damage_spells = {
         // spell_damage_near spells (caster area) - sorted by MP cost
@@ -704,8 +699,7 @@ async::task<bool> skill_test::test_near_damage_spells(const std::vector<std::sha
     fb::logger::info("Cleaning up all learned spells");
     std::ignore = co_await this->clear_all_spells(caster, timeout);
 
-    caster->send(fb::protocol::game::request::move{DIRECTION::TOP, caster->oid(), target_position});
-    caster->set_position(original_position);
+    co_await caster->move(DIRECTION::TOP);
     caster->send(fb::protocol::game::request::direction{DIRECTION::BOTTOM});
 
     caster->send(fb::protocol::game::request::chat(false, "=== NEAR DAMAGE SPELL TEST COMPLETED ==="));
@@ -713,8 +707,8 @@ async::task<bool> skill_test::test_near_damage_spells(const std::vector<std::sha
     co_return true;
 }
 
-async::task<bool> skill_test::test_attack_cast_spells(const std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
-                                                      std::chrono::milliseconds                              timeout)
+async::task<bool> skill_test::test_attack_cast_spells(std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
+                                                      std::chrono::milliseconds                        timeout)
 {
     constexpr auto interval = 100ms;
 
@@ -728,7 +722,10 @@ async::task<bool> skill_test::test_attack_cast_spells(const std::vector<std::sha
     co_await thread->switching();
 
     // Setup all bots with max HP/MP
-    std::ignore = co_await this->setup_bots_hp_mp(bots, 100000, 100000, std::nullopt, std::nullopt, timeout);
+    for (auto& bot : bots)
+    {
+        std::ignore = co_await this->setup_bot_stats(bot, 100000, 100000, std::nullopt, std::nullopt, timeout);
+    }
 
     std::vector<attack_cast_spell_test> attack_cast_spells = {
         // Single target attack spells (front target)
@@ -844,8 +841,8 @@ async::task<bool> skill_test::test_attack_cast_spells(const std::vector<std::sha
 }
 
 async::task<bool>
-skill_test::test_multi_target_attack_cast_spells(const std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
-                                                 std::chrono::milliseconds                              timeout)
+skill_test::test_multi_target_attack_cast_spells(std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
+                                                 std::chrono::milliseconds                        timeout)
 {
     constexpr auto interval = 100ms;
 
@@ -858,7 +855,10 @@ skill_test::test_multi_target_attack_cast_spells(const std::vector<std::shared_p
     co_await thread->switching();
 
     // Setup all bots with max HP/MP
-    std::ignore = co_await this->setup_bots_hp_mp(bots, 100000, 100000, std::nullopt, std::nullopt, timeout);
+    for (auto& bot : bots)
+    {
+        std::ignore = co_await this->setup_bot_stats(bot, 100000, 100000, std::nullopt, std::nullopt, timeout);
+    }
 
     std::vector<multi_target_attack_cast_spell_test> multi_target_spells = {
         // Multi-target attack spells
@@ -938,7 +938,6 @@ skill_test::test_multi_target_attack_cast_spells(const std::vector<std::shared_p
     fb::logger::info("Learning {} multi-target attack_cast spells", multi_target_spells.size());
     auto spell_slot = 1;
 
-    auto original_position = caster->position();
     for (const auto& spell : multi_target_spells)
     {
         fb::logger::info("Testing multi-target spell: {}", spell.name);
@@ -973,8 +972,7 @@ skill_test::test_multi_target_attack_cast_spells(const std::vector<std::shared_p
         spell_slot++;
 
         // Move bot back to original position if it moved
-        co_await this->move_bot_back_to_position(caster, original_position, interval);
-
+        co_await this->move_bot_back_to_position(caster, caster_pos, interval);
         co_await caster->thread()->sleep(interval);
     }
 
@@ -989,8 +987,9 @@ skill_test::test_multi_target_attack_cast_spells(const std::vector<std::shared_p
 
 void skill_test::reset()
 {
-    this->_test_completed           = false;
-    this->_test_running             = false;
+    // Call base class reset
+    bot_integration_test::reset();
+
     this->_waiting_for_spell_update = false;
     this->_spell_learned_index      = 0;
 
@@ -1002,14 +1001,15 @@ void skill_test::reset()
 
 bool skill_test::is_ready() const
 {
-    auto& bots = this->get_test_bots();
-    if (bots.empty())
+    if (this->get_test_bots().empty())
         return false;
 
-    // Movement test requires all bots to have non-zero oid
-    for (const auto& bot : bots)
+    for (auto& bot : this->get_test_bots())
     {
-        if (bot->oid() == 0)
+        if (bot->oid() == 0 && bot->oid() != 0xFFFFFFFD)
+            return false;
+
+        if (bot->position().x == 0 && bot->position().y == 0)
             return false;
     }
 
@@ -1018,7 +1018,8 @@ bool skill_test::is_ready() const
 
 void skill_test::on_bot_connected(std::shared_ptr<fb::bot::game_bot> bot)
 {
-    this->_test_bots.push_back(bot);
+    // Call base class implementation
+    bot_integration_test::on_bot_connected(bot);
     fb::logger::debug("Skill test: Bot {} added to collection", bot->fd());
 }
 
@@ -1030,37 +1031,68 @@ void skill_test::on_spell_update_received(std::shared_ptr<fb::bot::game_bot> bot
     this->_waiting_for_spell_update = false;
 }
 
+async::task<void> skill_test::on_hook_sequence(fb::bot::game_bot& bot, const fb::protocol::game::response::id& response)
+{
+    fb::logger::debug("Skill test: Bot {} received object ID {}", bot.fd(), response.oid);
+
+    if (this->is_ready() == false)
+        co_return;
+
+    if (this->get_state() == test_state::running)
+        co_return;
+
+    fb::logger::info("Skill test: All bots ready, notifying controller");
+    this->set_state(test_state::ready);
+    this->notify_ready();
+    co_return;
+}
+
+async::task<void> skill_test::on_hook_position(fb::bot::game_bot&                            bot,
+                                               const fb::protocol::game::response::position& response)
+{
+    if (this->is_ready() == false)
+        co_return;
+
+    if (this->get_state() == test_state::running)
+        co_return;
+
+    fb::logger::info("Skill test: All bots ready, notifying controller");
+    this->set_state(test_state::ready);
+    this->notify_ready();
+    co_return;
+}
+
 void skill_test::initialize_test_functions()
 {
     // Clear existing test functions
     this->_test_functions.clear();
 
     // Register all test functions in execution order
-    this->_test_functions.emplace_back("Healing Spells", [this](const auto& bots, auto timeout) {
+    this->_test_functions.emplace_back("Healing Spells", [this](auto& bots, auto timeout) {
         return this->test_healing_spells(bots, timeout);
     });
 
-    this->_test_functions.emplace_back("Damage Spells", [this](const auto& bots, auto timeout) {
+    this->_test_functions.emplace_back("Damage Spells", [this](auto& bots, auto timeout) {
         return this->test_damage_spells(bots, timeout);
     });
 
-    this->_test_functions.emplace_back("Near Damage Spells", [this](const auto& bots, auto timeout) {
+    this->_test_functions.emplace_back("Near Damage Spells", [this](auto& bots, auto timeout) {
         return this->test_near_damage_spells(bots, timeout);
     });
 
-    this->_test_functions.emplace_back("Attack Cast Spells", [this](const auto& bots, auto timeout) {
+    this->_test_functions.emplace_back("Attack Cast Spells", [this](auto& bots, auto timeout) {
         return this->test_attack_cast_spells(bots, timeout);
     });
 
-    this->_test_functions.emplace_back("Multi-Target Attack Cast Spells", [this](const auto& bots, auto timeout) {
+    this->_test_functions.emplace_back("Multi-Target Attack Cast Spells", [this](auto& bots, auto timeout) {
         return this->test_multi_target_attack_cast_spells(bots, timeout);
     });
 
     fb::logger::info("Initialized {} test functions", this->_test_functions.size());
 }
 
-async::task<bool> skill_test::execute_test_functions(const std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
-                                                     std::chrono::milliseconds                              timeout)
+async::task<bool> skill_test::execute_test_functions(std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
+                                                     std::chrono::milliseconds                        timeout)
 {
     fb::logger::info("Executing {} test functions", this->_test_functions.size());
 

--- a/bot/lib/integration/test/test_case.cpp
+++ b/bot/lib/integration/test/test_case.cpp
@@ -6,10 +6,9 @@
 
 namespace fb::bot::integration {
 
-// Base test class implementation
-void bot_integration_test::cleanup()
+void bot_integration_test::notify_ready()
 {
-    fb::logger::info("Test cleanup completed (base implementation)");
+    this->_controller.notify_test_ready();
 }
 
 // Utility functions for common bot operations
@@ -257,47 +256,44 @@ async::task<bool> bot_integration_test::set_current_hp_mp(std::shared_ptr<fb::bo
     co_return true; // Both commands should succeed if bot is valid
 }
 
-async::task<bool> bot_integration_test::setup_bots_hp_mp(const std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
-                                                         int                                                    max_hp,
-                                                         int                                                    max_mp,
-                                                         std::optional<int>        current_hp,
-                                                         std::optional<int>        current_mp,
-                                                         std::chrono::milliseconds timeout)
+async::task<bool> bot_integration_test::setup_bot_stats(std::shared_ptr<fb::bot::game_bot> bot,
+                                                        int                                max_hp,
+                                                        int                                max_mp,
+                                                        std::optional<int>                 current_hp,
+                                                        std::optional<int>                 current_mp,
+                                                        std::chrono::milliseconds          timeout)
 {
-    for (auto& bot : bots)
+    auto thread = bot->thread();
+    co_await thread->switching();
+
+    // Set max HP/MP
+    std::ignore = co_await bot->request<fb::protocol::game::response::update_internal>(
+        fb::protocol::game::request::chat{false, std::format("/체력바꾸기 {}", max_hp)},
+        timeout);
+
+    std::ignore = co_await bot->request<fb::protocol::game::response::update_internal>(
+        fb::protocol::game::request::chat{false, std::format("/마력바꾸기 {}", max_mp)},
+        timeout);
+
+    // Set current HP/MP if specified
+    if (current_hp.has_value())
     {
-        auto thread = bot->thread();
-        co_await thread->switching();
-
-        // Set max HP/MP
         std::ignore = co_await bot->request<fb::protocol::game::response::update_internal>(
-            fb::protocol::game::request::chat{false, std::format("/체력바꾸기 {}", max_hp)},
+            fb::protocol::game::request::chat{false, std::format("/현재체력 {}", current_hp.value())},
+            [current_hp](auto& resp) -> bool {
+                return resp.ch_hp == current_hp.value();
+            },
             timeout);
+    }
 
+    if (current_mp.has_value())
+    {
         std::ignore = co_await bot->request<fb::protocol::game::response::update_internal>(
-            fb::protocol::game::request::chat{false, std::format("/마력바꾸기 {}", max_mp)},
+            fb::protocol::game::request::chat{false, std::format("/현재마력 {}", current_mp.value())},
+            [current_mp](auto& resp) -> bool {
+                return resp.ch_mp == current_mp.value();
+            },
             timeout);
-
-        // Set current HP/MP if specified
-        if (current_hp.has_value())
-        {
-            std::ignore = co_await bot->request<fb::protocol::game::response::update_internal>(
-                fb::protocol::game::request::chat{false, std::format("/현재체력 {}", current_hp.value())},
-                [current_hp](auto& resp) -> bool {
-                    return resp.ch_hp == current_hp.value();
-                },
-                timeout);
-        }
-
-        if (current_mp.has_value())
-        {
-            std::ignore = co_await bot->request<fb::protocol::game::response::update_internal>(
-                fb::protocol::game::request::chat{false, std::format("/현재마력 {}", current_mp.value())},
-                [current_mp](auto& resp) -> bool {
-                    return resp.ch_mp == current_mp.value();
-                },
-                timeout);
-        }
     }
 
     co_return true;
@@ -345,7 +341,7 @@ async::task<bool> bot_integration_test::clear_all_spells(std::shared_ptr<fb::bot
 
 async::task<void> bot_integration_test::move_bot_back_to_position(std::shared_ptr<fb::bot::game_bot> bot,
                                                                   const fb::model::point<uint16_t>&  original_position,
-                                                                  std::chrono::milliseconds          interval)
+                                                                  const fb::model::timespan&         interval)
 {
     auto thread = bot->thread();
     co_await thread->switching();

--- a/game/lib/spell.cpp
+++ b/game/lib/spell.cpp
@@ -184,7 +184,7 @@ bool buffs::push_back(const std::shared_ptr<buff>& buff)
     if (this->contains(model.id))
         return false;
 
-    this->insert({model.id, std::move(buff)});
+    this->insert({model.id, buff});
 
     // Execute buff script
     if (buff->model.buff.empty() == false)

--- a/include/fb/bot/controller.h
+++ b/include/fb/bot/controller.h
@@ -354,8 +354,10 @@ public:
                         if (shared == nullptr)
                             co_return;
 
-                        [[maybe_unused]] volatile auto holder = protocol;
+                        [[maybe_unused]] volatile auto holder     = protocol;
+                        [[maybe_unused]] volatile auto controller = this;
                         co_await handler(*shared, *protocol.get());
+                        co_await controller->on_integration_hook_execution(cmd, *shared, *protocol.get());
                         shared->process_hooks(cmd, *protocol.get());
                     });
                 }
@@ -424,11 +426,20 @@ public:
                  co_return protocol;
              }});
 
-        this->_handler.insert({ResponseType::header, [this, fn](auto& bot, auto& header) -> async::task<void> {
-                                   auto protocol = static_cast<ResponseType&>(header);
-                                   co_await fn(bot, protocol);
-                                   bot.process_hooks(ResponseType::header, header);
-                               }});
+        this->_handler.insert(
+            {ResponseType::header, [this, fn](auto& bot, auto& header) -> async::task<void> {
+                 auto                           protocol   = static_cast<ResponseType&>(header);
+                 [[maybe_unused]] volatile auto controller = this;
+
+                 // 1. Execute the main handler
+                 co_await fn(bot, protocol);
+
+                 // 2. Execute integration hooks
+                 co_await controller->on_integration_hook_execution(ResponseType::header, bot, header);
+
+                 // 3. Execute bot's process_hooks
+                 bot.process_hooks(ResponseType::header, header);
+             }});
     }
 
     /**
@@ -524,6 +535,26 @@ public:
     void write_bots(const std::function<void(std::unordered_map<uint32_t, std::shared_ptr<BotType>>&)>& fn)
     {
         this->_bots.write(fn);
+    }
+
+    /**
+     * @brief      Virtual method for integration hook execution.
+     *
+     *             This method is called when a protocol message is received.
+     *             Derived controllers can override this to implement custom hook logic.
+     *
+     * @param[in]  cmd     The command identifier.
+     * @param[in]  bot     The bot that received the message.
+     * @param[in]  header  The protocol header.
+     *
+     * @return     An async task that completes when hook processing is finished.
+     */
+    virtual async::task<void> on_integration_hook_execution(uint8_t                     cmd,
+                                                            BotType&                    bot,
+                                                            const fb::protocol::header& header)
+    {
+        // Default implementation does nothing
+        co_return;
     }
 };
 

--- a/include/fb/bot/game_bot.h
+++ b/include/fb/bot/game_bot.h
@@ -587,6 +587,15 @@ public:
     void set_name(const std::string& value);
 
     /**
+     * @brief      Move the bot in the specified direction.
+     *
+     * @param[in]  direction  The direction to move.
+     * @param[in]  step       The number of steps to move.
+     * @param[in]  delay      The delay between steps.
+     */
+    async::task<void> move(DIRECTION direction, int step = 1, const fb::model::timespan& delay = 0ms);
+
+    /**
      * @brief      Automated pattern for sending chat messages.
      *
      * @return     An async task that completes when chat action is finished.

--- a/include/fb/bot/integration/attack_test.h
+++ b/include/fb/bot/integration/attack_test.h
@@ -2,28 +2,34 @@
 #define __BOT_INTEGRATION_ATTACK_TEST_H__
 
 #include <fb/bot/integration/test_case.h>
+#include <fb/bot/integration/game_controller.h>
+#include <fb/game/protocol.h>
+#include <vector>
+#include <memory>
 
 namespace fb::bot::integration {
 
 /**
  * @brief      Attack integration test implementation.
  *
- *             Tests bot attack functionality by spawning a single bot and
- *             performing 10 attack sequences with 1-second intervals.
+ *             Tests bot attack functionality by spawning a monster and having
+ *             the bot attack it until the monster is defeated.
  */
 class attack_test : public bot_integration_test
 {
-private:
-    bool _test_completed{false};
-    bool _test_running{false};
-
-    std::vector<std::shared_ptr<fb::bot::game_bot>> _test_bots; ///< Attack test's own bot collection
-
-    static constexpr int ATTACK_COUNT = 5;
-
 public:
     /**
-     * @brief      Initializes the attack test and spawns a single bot.
+     * @brief      Constructs a new attack test with controller reference.
+     *
+     *             Initializes the attack test and registers hooks for specific
+     *             protocol types to enable event-driven test execution.
+     *
+     * @param[in]  controller  Reference to the parent game bot controller.
+     */
+    attack_test(game_bot_controller& controller);
+
+    /**
+     * @brief      Initializes the attack test and spawns required bots.
      *
      *             Spawns 1 bot for attack testing and waits for it to connect.
      *
@@ -31,86 +37,63 @@ public:
      *
      * @return     A task that completes when initialization is finished.
      */
-    async::task<void> initialize(game_bot_controller& controller) override;
+    async::task<void> initialize(game_bot_controller& controller);
 
     /**
      * @brief      Executes the attack test.
      *
-     *             Performs 10 attack sequences with 1-second intervals using
-     *             the spawned bot to test combat functionality.
+     *             Spawns a monster and has the bot attack it until defeated.
+     *             This method is called only when all bots are ready (have non-zero oid).
      *
      * @return     A task that completes when attack test finishes, returning true on success.
      */
-    async::task<bool> execute() override;
+    async::task<bool> execute();
 
     /**
-     * @brief      Checks if the attack test has completed.
-     *
-     * @return     True if all attack sequences are finished.
-     */
-    bool is_complete() const override
-    {
-        return this->_test_completed;
-    }
-
-    /**
-     * @brief      Resets the attack test state to initial conditions.
-     */
-    void reset() override;
-
-    /**
-     * @brief      Gets the attack test name.
+     * @brief      Gets the test name.
      *
      * @return     "Attack Test" as the identifier.
      */
-    std::string name() const override
+    std::string name() const
     {
         return "Attack Test";
     }
 
     /**
-     * @brief      Checks if the attack test is currently running.
+     * @brief      Called when a bot receives an object ID response.
      *
-     * @return     True if the test is in progress.
+     *             Checks if all bots are ready and starts the test if conditions are met.
+     *
+     * @param[in]  bot       The bot that received the object ID.
+     * @param[in]  response  The object ID response containing the new ID.
+     *
+     * @return     An async task that completes when hook processing is finished.
      */
-    bool is_running() const override
-    {
-        return this->_test_running;
-    }
+    async::task<void> on_hook_sequence(fb::bot::game_bot& bot, const fb::protocol::game::response::id& response);
 
     /**
-     * @brief      Checks if all spawned bots are ready for attack test.
-     *
-     *             Attack test requires the single bot to have received its oid ID
-     *             (oid != 0) before starting the test.
-     *
-     * @return     True if the spawned bot has non-zero oid, false otherwise.
+     * @brief      Resets the test state to idle.
      */
-    bool is_ready() const override;
+    void reset();
 
     /**
-     * @brief      Called when a bot connects to the attack test.
+     * @brief      Checks if the test is ready to start execution.
      *
-     *             Adds the bot to the attack test's bot collection.
-     *
-     * @param[in]  bot  The connected bot to add to the test.
+     * @return     True if the test is ready to start, false otherwise.
      */
-    void on_bot_connected(std::shared_ptr<fb::bot::game_bot> bot) override;
+    bool is_ready() const;
 
     /**
-     * @brief      Cleans up attack test resources and disconnects the spawned bot.
+     * @brief      Called when a bot connects to the test.
      *
-     *             Overrides base cleanup to handle attack test specific bot collection.
+     * @param[in]  bot  Shared pointer to the connected bot.
      */
-    void cleanup() override;
+    void on_bot_connected(std::shared_ptr<fb::bot::game_bot> bot);
 
-protected:
     /**
-     * @brief      Gets the current list of attack test bots (thread-safe).
-     *
-     * @return     Vector of shared pointers to the attack test bots.
+     * @brief      Performs cleanup operations when the test is destroyed.
      */
-    std::vector<std::shared_ptr<fb::bot::game_bot>> get_test_bots() const;
+    void cleanup();
 };
 
 } // namespace fb::bot::integration

--- a/include/fb/bot/integration/game_controller.h
+++ b/include/fb/bot/integration/game_controller.h
@@ -8,6 +8,11 @@
 #include <fb/locker.h>
 #include <memory>
 #include <queue>
+#include <vector>
+#include <unordered_map>
+#include <typeindex>
+#include <functional>
+#include <shared_mutex>
 
 namespace fb::bot::integration {
 
@@ -19,15 +24,20 @@ namespace fb::bot::integration {
  *             and comprehensive test case management. Unlike load testing,
  *             it focuses on functional correctness and system behavior validation.
  *
- *             The controller manages various test cases (movement, attack, skill tests)
+ *             The controller manages test instances for lifetime management
  *             and coordinates their execution across multiple bots.
  */
 class game_bot_controller : public fb::bot::game_bot_controller
 {
 private:
-    fb::locker<std::unique_ptr<bot_integration_test>>
-        _current_test; ///< Currently active test case with thread-safe access
-    std::queue<std::unique_ptr<bot_integration_test>> _test_queue; ///< Queue of tests to execute in oid
+    std::vector<std::unique_ptr<bot_integration_test>> _test_instances; ///< Test instances for lifetime management
+    std::queue<bot_integration_test*>                  _test_queue;     ///< Queue of tests to execute
+    bot_integration_test* _current_test{nullptr};                       ///< Currently active test (non-owning pointer)
+
+    // Hook system for integration tests - per test
+    using hook_function = std::function<async::task<void>(game_bot&, const fb::protocol::header&)>;
+    std::unordered_map<bot_integration_test*, std::unordered_map<uint8_t, std::vector<hook_function>>> _test_hooks;
+    std::shared_mutex _hook_mutex; ///< Mutex for thread-safe hook operations
 
 public:
     using bot_type = game_bot; ///< Type alias for the managed bot type
@@ -68,40 +78,124 @@ public:
 
 public:
     /**
-     * @brief      Sets the current integration test case.
+     * @brief      Notifies the controller that a test has completed.
      *
-     *             Replaces the current test with a new one and resets its state.
-     *             If a test is currently running, it will be stopped first.
+     *             Called by test instances when they finish execution.
      *
-     * @param      test  Unique pointer to the new test case.
+     * @param[in]  test  Pointer to the test that has completed.
      */
-    async::task<void> set_test(std::unique_ptr<bot_integration_test> test);
+    void notify_test_completed(bot_integration_test* test);
 
     /**
-     * @brief      Starts the current integration test.
+     * @brief      Notifies the controller that the current test is ready to start.
      *
-     *             Executes the currently set test case with all connected bots.
-     *             If no test is set or a test is already running, this method returns immediately.
-     *
-     * @return     An async task that completes when the test finishes, returning true on success.
+     *             Called by test instances when they detect they are ready to begin execution.
      */
-    async::task<bool> start_test();
+    void notify_test_ready();
 
     /**
-     * @brief      Resets the current test case to initial state.
+     * @brief      Starts the current test.
      *
-     *             Stops any running test and resets its internal state.
+     *             Called when the current test notifies it is ready.
      */
-    void reset_current_test();
+    async::task<void> start_current_test();
 
-private:
     /**
-     * @brief      Starts the next test from the queue.
+     * @brief      Adds a test to the execution queue.
      *
-     *             Moves to the next test in the queue and initializes it.
-     *             If the queue is empty, logs completion of all tests.
+     * @param[in]  test  Unique pointer to the test to add.
      */
-    async::task<void> start_next_test();
+    void enqueue_test(std::unique_ptr<bot_integration_test> test);
+
+    /**
+     * @brief      Starts the next test in the queue.
+     *
+     *             Called when the current test completes.
+     */
+    void start_next_test();
+
+    /**
+     * @brief      Checks if there are more tests in the queue.
+     *
+     * @return     True if there are more tests, false otherwise.
+     */
+    bool has_more_tests() const;
+
+    /**
+     * @brief      Activates the first test in the queue.
+     *
+     *             This method initializes the first test by creating bots,
+     *             registering hooks, and performing other setup tasks.
+     *             This is different from starting the test - activation
+     *             prepares the test to become ready.
+     */
+    async::task<void> activate_first_test();
+
+    /**
+     * @brief      Registers a hook for a specific protocol type for a test.
+     *
+     *             This method should be called by tests to register their hooks.
+     *             Only hooks for the current test will be executed.
+     *
+     * @param[in]  test  Pointer to the test instance registering the hook.
+     * @param[in]  fn    The hook function to register.
+     *
+     * @tparam     ResponseType  The protocol response type to hook.
+     */
+    template <typename ResponseType>
+    void hook_for_test(bot_integration_test*                                                   test,
+                       const std::function<async::task<void>(game_bot&, const ResponseType&)>& fn)
+    {
+        auto hook_func = [fn](game_bot& bot, const fb::protocol::header& header) -> async::task<void> {
+            auto& protocol = static_cast<const ResponseType&>(header);
+            co_await fn(bot, protocol);
+        };
+
+        auto unique_lock = std::unique_lock<std::shared_mutex>(this->_hook_mutex);
+        this->_test_hooks[test][ResponseType::header].push_back(hook_func);
+    }
+
+    /**
+     * @brief      Registers a member function as a hook for a specific protocol type from external class.
+     *
+     *             Allows external classes to register hooks by passing the class instance pointer.
+     *
+     * @param[in]  test      Pointer to the test instance registering the hook.
+     * @param[in]  instance  Pointer to the class instance.
+     * @param[in]  fn        The member function to register as hook.
+     *
+     * @tparam     Class         The class type containing the member function.
+     * @tparam     ResponseType  The protocol response type to hook.
+     */
+    template <typename Class, typename ResponseType>
+    void hook_external(bot_integration_test* test,
+                       Class*                instance,
+                       async::task<void> (Class::*fn)(game_bot&, const ResponseType&))
+    {
+        auto hook_func = [instance, fn](game_bot& bot, const fb::protocol::header& header) -> async::task<void> {
+            auto& protocol = static_cast<const ResponseType&>(header);
+            co_await (instance->*fn)(bot, protocol);
+        };
+
+        auto unique_lock = std::unique_lock<std::shared_mutex>(this->_hook_mutex);
+        this->_test_hooks[test][ResponseType::header].push_back(hook_func);
+    }
+
+protected:
+    /**
+     * @brief      Overrides the base controller's integration hook execution.
+     *
+     *             This method executes hooks for the current test only.
+     *
+     * @param[in]  cmd     The command identifier.
+     * @param[in]  bot     The bot that received the message.
+     * @param[in]  header  The protocol header.
+     *
+     * @return     An async task that completes when hook processing is finished.
+     */
+    async::task<void> on_integration_hook_execution(uint8_t                     cmd,
+                                                    game_bot&                   bot,
+                                                    const fb::protocol::header& header) override;
 
 private:
     /**

--- a/include/fb/bot/integration/movement_test.h
+++ b/include/fb/bot/integration/movement_test.h
@@ -2,6 +2,8 @@
 #define __BOT_INTEGRATION_MOVEMENT_TEST_H__
 
 #include <fb/bot/integration/test_case.h>
+#include <fb/bot/integration/game_controller.h>
+#include <fb/game/protocol.h>
 #include <vector>
 #include <memory>
 
@@ -16,105 +18,85 @@ namespace fb::bot::integration {
 class movement_test : public bot_integration_test
 {
 private:
-    bool _test_started{false};
-    bool _test_completed{false};
-    bool _test_running{false};
-
-    std::vector<std::shared_ptr<fb::bot::game_bot>> _test_bots; ///< Movement test's own bot collection
-
     static constexpr int MOVEMENT_STEPS = 5;
 
 public:
     /**
+     * @brief      Constructs a new movement test with controller reference.
+     *
+     *             Initializes the movement test and registers hooks for specific
+     *             protocol types to enable event-driven test execution.
+     *
+     * @param[in]  controller  Reference to the parent game bot controller.
+     */
+    movement_test(game_bot_controller& controller);
+
+    /**
      * @brief      Initializes the movement test and spawns required bots.
      *
-     *             Spawns 5 bots for movement testing and waits for them to connect.
+     *             Spawns 1 bot for movement testing and waits for it to connect.
      *
      * @param[in]  controller  The game bot controller to use for spawning bots.
-     * @param[in]  endpoint    The server endpoint to connect bots to.
      *
      * @return     A task that completes when initialization is finished.
      */
-    async::task<void> initialize(game_bot_controller& controller) override;
+    async::task<void> initialize(game_bot_controller& controller);
 
     /**
      * @brief      Executes the movement test.
      *
-     *             Moves the last bot downward step by step with timing intervals.
+     *             Moves the bot in a square pattern to test movement functionality.
      *             This method is called only when all bots are ready (have non-zero oid).
      *
      * @return     A task that completes when movement test finishes, returning true on success.
      */
-    async::task<bool> execute() override;
-
-    /**
-     * @brief      Checks if the movement test has completed.
-     *
-     * @return     True if all movement steps are finished.
-     */
-    bool is_complete() const override
-    {
-        return this->_test_completed;
-    }
-
-    /**
-     * @brief      Resets the movement test state.
-     */
-    void reset() override;
+    async::task<bool> execute();
 
     /**
      * @brief      Gets the test name.
      *
      * @return     "Movement Test" as the identifier.
      */
-    std::string name() const override
+    std::string name() const
     {
         return "Movement Test";
     }
 
     /**
-     * @brief      Checks if the movement test is currently running.
+     * @brief      Called when a bot receives an object ID response.
      *
-     * @return     True if the test is in progress.
+     *             Checks if all bots are ready and starts the test if conditions are met.
+     *
+     * @param[in]  bot       The bot that received the object ID.
+     * @param[in]  response  The object ID response containing the new ID.
+     *
+     * @return     An async task that completes when hook processing is finished.
      */
-    bool is_running() const override
-    {
-        return this->_test_running;
-    }
+    async::task<void> on_hook_sequence(fb::bot::game_bot& bot, const fb::protocol::game::response::id& response);
 
     /**
-     * @brief      Checks if all spawned bots are ready for movement test.
-     *
-     *             Movement test requires all bots to have received their oid IDs
-     *             (oid != 0) before starting the test.
-     *
-     * @return     True if all spawned bots have non-zero oid, false otherwise.
+     * @brief      Resets the test state to idle.
      */
-    bool is_ready() const override;
+    void reset();
 
     /**
-     * @brief      Called when a bot connects to the movement test.
+     * @brief      Checks if the test is ready to start execution.
      *
-     *             Adds the bot to the movement test's bot collection.
-     *
-     * @param[in]  bot  The connected bot to add to the test.
+     * @return     True if the test is ready to start, false otherwise.
      */
-    void on_bot_connected(std::shared_ptr<fb::bot::game_bot> bot) override;
+    bool is_ready() const;
 
     /**
-     * @brief      Cleans up movement test resources and disconnects all spawned bots.
+     * @brief      Called when a bot connects to the test.
      *
-     *             Overrides base cleanup to handle movement test specific bot collection.
+     * @param[in]  bot  Shared pointer to the connected bot.
      */
-    void cleanup() override;
+    void on_bot_connected(std::shared_ptr<fb::bot::game_bot> bot);
 
-protected:
     /**
-     * @brief      Gets the current list of movement test bots (thread-safe).
-     *
-     * @return     Vector of shared pointers to the movement test bots.
+     * @brief      Performs cleanup operations when the test is destroyed.
      */
-    std::vector<std::shared_ptr<fb::bot::game_bot>> get_test_bots() const;
+    void cleanup();
 };
 
 } // namespace fb::bot::integration

--- a/include/fb/bot/integration/skill_test.h
+++ b/include/fb/bot/integration/skill_test.h
@@ -14,25 +14,29 @@ namespace fb::bot::integration {
 class skill_test : public bot_integration_test
 {
 private:
-    bool _test_completed{false};
-    bool _test_running{false};
-
-    std::vector<std::shared_ptr<fb::bot::game_bot>> _test_bots; ///< Skill test's own bot collection
-
     // Spell learning tracking
     bool    _waiting_for_spell_update{false};
     uint8_t _spell_learned_index{0};
 
     // Test function queue management
-    using test_function = std::function<async::task<bool>(const std::vector<std::shared_ptr<fb::bot::game_bot>>&,
-                                                          std::chrono::milliseconds)>;
+    using test_function =
+        std::function<async::task<bool>(std::vector<std::shared_ptr<fb::bot::game_bot>>&, std::chrono::milliseconds)>;
     std::vector<std::pair<std::string, test_function>> _test_functions;
 
     static constexpr int SPELL_CAST_COUNT = 10;
 
 public:
     /**
-     * @brief      Initializes the skill test and spawns a single bot.
+     * @brief      Constructs a new skill test with controller reference.
+     *
+     *             Initializes the skill test and registers hooks for specific
+     *             protocol types to enable event-driven test execution.
+     *
+     * @param[in]  controller  Reference to the parent game bot controller.
+     */
+    skill_test(game_bot_controller& controller);
+    /**
+     * @brief      Initializes the skill test and spawns required bots.
      *
      *             Spawns 1 bot for skill testing and waits for it to connect.
      *
@@ -40,27 +44,17 @@ public:
      *
      * @return     A task that completes when initialization is finished.
      */
-    async::task<void> initialize(game_bot_controller& controller) override;
+    async::task<void> initialize(game_bot_controller& controller);
 
     /**
      * @brief      Executes the skill test.
      *
-     *             Tests bot skill casting functionality by sending a spell learning chat,
-     *             waiting for spell_update response, then casting the learned spell 10 times.
+     *             Tests various skill functionalities by spawning monsters and
+     *             having the bot use skills against them.
      *
      * @return     A task that completes when skill test finishes, returning true on success.
      */
-    async::task<bool> execute() override;
-
-    /**
-     * @brief      Checks if the skill test has completed.
-     *
-     * @return     True if all skill casting sequences are finished.
-     */
-    bool is_complete() const override
-    {
-        return this->_test_completed;
-    }
+    async::task<bool> execute();
 
     /**
      * @brief      Resets the skill test state to initial conditions.
@@ -68,23 +62,13 @@ public:
     void reset() override;
 
     /**
-     * @brief      Gets the skill test name.
+     * @brief      Gets the test name.
      *
      * @return     "Skill Test" as the identifier.
      */
-    std::string name() const override
+    std::string name() const
     {
         return "Skill Test";
-    }
-
-    /**
-     * @brief      Checks if the skill test is currently running.
-     *
-     * @return     True if the test is in progress.
-     */
-    bool is_running() const override
-    {
-        return this->_test_running;
     }
 
     /**
@@ -117,17 +101,29 @@ public:
      */
     void on_spell_update_received(std::shared_ptr<fb::bot::game_bot> bot, uint8_t index);
 
-private:
     /**
-     * @brief      Gets the list of connected test bots.
+     * @brief      Called when a bot receives an object ID response.
      *
-     * @return     Vector of test bots for skill testing.
+     *             Checks if all bots are ready and starts the test if conditions are met.
+     *
+     * @param[in]  bot       The bot that received the object ID.
+     * @param[in]  response  The object ID response containing the new ID.
+     *
+     * @return     An async task that completes when hook processing is finished.
      */
-    const std::vector<std::shared_ptr<fb::bot::game_bot>>& get_test_bots() const
-    {
-        return this->_test_bots;
-    }
+    async::task<void> on_hook_sequence(fb::bot::game_bot& bot, const fb::protocol::game::response::id& response);
 
+    /**
+     * @brief      Called when a bot receives a position response.
+     *
+     * @param[in]  bot       The bot that received the position.
+     * @param[in]  response  The position response containing the new position.
+     *
+     * @return     An async task that completes when hook processing is finished.
+     */
+    async::task<void> on_hook_position(fb::bot::game_bot& bot, const fb::protocol::game::response::position& response);
+
+private:
     /**
      * @brief      Initializes the test function queue with all test functions.
      *
@@ -143,8 +139,8 @@ private:
      *
      * @return     A task that completes when all test functions finish.
      */
-    async::task<bool> execute_test_functions(const std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
-                                             std::chrono::milliseconds                              timeout);
+    async::task<bool> execute_test_functions(std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
+                                             std::chrono::milliseconds                        timeout);
 
     /**
      * @brief      Tests healing spells with comprehensive spell coverage.
@@ -159,20 +155,20 @@ private:
      *
      * @return     A task that completes when all healing spell tests finish.
      */
-    async::task<bool> test_healing_spells(const std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
-                                          std::chrono::milliseconds                              timeout);
+    async::task<bool> test_healing_spells(std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
+                                          std::chrono::milliseconds                        timeout);
 
-    async::task<bool> test_damage_spells(const std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
-                                         std::chrono::milliseconds                              timeout);
+    async::task<bool> test_damage_spells(std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
+                                         std::chrono::milliseconds                        timeout);
 
-    async::task<bool> test_near_damage_spells(const std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
-                                              std::chrono::milliseconds                              timeout);
+    async::task<bool> test_near_damage_spells(std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
+                                              std::chrono::milliseconds                        timeout);
 
-    async::task<bool> test_attack_cast_spells(const std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
-                                              std::chrono::milliseconds                              timeout);
+    async::task<bool> test_attack_cast_spells(std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
+                                              std::chrono::milliseconds                        timeout);
 
-    async::task<bool> test_multi_target_attack_cast_spells(const std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
-                                                           std::chrono::milliseconds timeout);
+    async::task<bool> test_multi_target_attack_cast_spells(std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
+                                                           std::chrono::milliseconds                        timeout);
 
     /**
      * @brief      Structure for healing spell test data

--- a/include/fb/bot/integration/test_case.h
+++ b/include/fb/bot/integration/test_case.h
@@ -34,11 +34,152 @@ struct spawned_monster_info
  *             Provides a framework for creating various types of integration tests
  *             such as movement, attack, skill tests, etc. Each test manages its own
  *             state, spawns bots as needed, and cleans up resources when complete.
+ *             Tests can be chained together to form a linked list for sequential execution.
  */
 class bot_integration_test
 {
 public:
+    enum class test_state : uint8_t
+    {
+        idle,      ///< Test is not started yet
+        ready,     ///< Test is ready to start
+        running,   ///< Test is currently executing
+        completed, ///< Test has completed successfully
+        failed     ///< Test has failed
+    };
+
+protected:
+    game_bot_controller&                            _controller; ///< Reference to the parent game bot controller
+    std::vector<std::shared_ptr<fb::bot::game_bot>> _test_bots;  ///< Collection of bots managed by this test
+    test_state                                      _state{test_state::idle}; ///< Current state of the test
+
+protected:
+    // No additional protected members
+
+public:
+    /**
+     * @brief      Constructs a new bot integration test with controller reference.
+     *
+     * @param[in]  controller  Reference to the game bot controller.
+     */
+    bot_integration_test(game_bot_controller& controller) :
+        _controller(controller)
+    { }
+
     virtual ~bot_integration_test() = default;
+
+    /**
+     * @brief      Gets the current state of the test.
+     *
+     * @return     The current test state.
+     */
+    test_state get_state() const
+    {
+        return this->_state;
+    }
+
+    /**
+     * @brief      Sets the current state of the test.
+     *
+     * @param[in]  state  The new test state.
+     */
+    void set_state(test_state state)
+    {
+        this->_state = state;
+    }
+
+    /**
+     * @brief      Checks if the test has completed execution.
+     *
+     * @return     True if the test is complete, false otherwise.
+     */
+    bool is_complete() const
+    {
+        return this->_state == test_state::completed;
+    }
+
+    /**
+     * @brief      Checks if the test is currently running.
+     *
+     * @return     True if the test is running, false otherwise.
+     */
+    bool is_running() const
+    {
+        return this->_state == test_state::running;
+    }
+
+    /**
+     * @brief      Called when a bot connects to the test.
+     *
+     *             Default implementation adds the bot to the test's bot collection.
+     *             Can be overridden by derived classes for custom behavior.
+     *
+     * @param[in]  bot  Shared pointer to the connected bot.
+     */
+    virtual void on_bot_connected(std::shared_ptr<fb::bot::game_bot> bot)
+    {
+        this->_test_bots.push_back(bot);
+    }
+
+    /**
+     * @brief      Called when a bot receives an object ID response.
+     *
+     *             This method is called by the hook system when a bot receives
+     *             an object ID. Derived classes should override this to check
+     *             readiness and notify the controller.
+     *
+     * @param[in]  bot       The bot that received the object ID.
+     * @param[in]  response  The object ID response.
+     *
+     * @return     An async task that completes when processing is finished.
+     */
+    virtual async::task<void> on_hook_sequence(fb::bot::game_bot& bot, const fb::protocol::game::response::id& response)
+    {
+        // Default implementation does nothing
+        co_return;
+    }
+
+    /**
+     * @brief      Notifies the controller that this test is ready to start.
+     *
+     *             Called by derived classes when they detect they are ready to begin execution.
+     */
+    void notify_ready();
+
+    /**
+     * @brief      Performs cleanup operations when the test is destroyed.
+     *
+     *             Default implementation does nothing. Can be overridden
+     *             by derived classes for custom cleanup logic.
+     */
+    virtual void cleanup()
+    {
+        // Default implementation does nothing
+    }
+
+    /**
+     * @brief      Checks if the test is ready to start execution.
+     *
+     *             This method should be overridden by derived classes to
+     *             implement specific readiness checks.
+     *
+     * @return     True if the test is ready to start, false otherwise.
+     */
+    virtual bool is_ready() const
+    {
+        // Default implementation: ready if we have at least one bot
+        return !this->_test_bots.empty();
+    }
+
+    /**
+     * @brief      Gets the current list of test bots.
+     *
+     * @return     Vector of shared pointers to the test bots.
+     */
+    std::vector<std::shared_ptr<fb::bot::game_bot>> get_test_bots() const
+    {
+        return this->_test_bots;
+    }
 
     /**
      * @brief      Initializes the test case and spawns required bots if needed.
@@ -70,61 +211,24 @@ public:
     virtual async::task<bool> execute() = 0;
 
     /**
-     * @brief      Checks if the test has completed.
-     *
-     * @return     True if the test is complete, false otherwise.
-     */
-    virtual bool is_complete() const = 0;
-
-    /**
-     * @brief      Resets the test state to initial conditions.
-     */
-    virtual void reset() = 0;
-
-    /**
      * @brief      Gets the name of the test for logging and identification.
      *
      * @return     The test name as a string.
      */
     virtual std::string name() const = 0;
 
-    /**
-     * @brief      Checks if the test is currently in progress.
-     *
-     * @return     True if the test is running, false otherwise.
-     */
-    virtual bool is_running() const = 0;
-
-    /**
-     * @brief      Checks if all spawned bots are ready to start the test.
-     *
-     *             Each test implementation defines its own readiness criteria.
-     *             For example, movement test might require all bots to have non-zero oid,
-     *             while attack test might require bots to be in specific positions.
-     *
-     * @return     True if all spawned bots are ready to start this test, false otherwise.
-     */
-    virtual bool is_ready() const = 0;
-
-    /**
-     * @brief      Called when a bot connects to the test.
-     *
-     *             Each test implementation can decide whether to store this bot
-     *             or ignore it based on its own requirements.
-     *
-     * @param[in]  bot  Shared pointer to the connected bot.
-     */
-    virtual void on_bot_connected(std::shared_ptr<fb::bot::game_bot> bot) = 0;
-
-    /**
-     * @brief      Cleans up test resources and disconnects all spawned bots.
-     *
-     *             This method is called when the test completes or needs to be stopped.
-     *             It ensures all bot connections are properly closed and resources are freed.
-     */
-    virtual void cleanup();
-
 protected:
+    /**
+     * @brief      Resets the test state to idle.
+     *
+     *             This method should be overridden by derived classes to
+     *             implement specific reset logic.
+     */
+    virtual void reset()
+    {
+        this->_state = test_state::idle;
+    }
+
     /**
      * @brief      Spawns a monster at the specified position with custom validator
      *
@@ -252,24 +356,12 @@ protected:
                                         int                                current_mp,
                                         std::chrono::milliseconds          timeout);
 
-    /**
-     * @brief      Sets HP and MP for multiple bots
-     *
-     * @param[in]  bots      Vector of bots to modify
-     * @param[in]  max_hp    Maximum HP value to set
-     * @param[in]  max_mp    Maximum MP value to set
-     * @param[in]  current_hp  Current HP value to set (optional, uses max_hp if not specified)
-     * @param[in]  current_mp  Current MP value to set (optional, uses max_mp if not specified)
-     * @param[in]  timeout   Request timeout duration
-     *
-     * @return     An async task that returns true if all bots were set successfully
-     */
-    async::task<bool> setup_bots_hp_mp(const std::vector<std::shared_ptr<fb::bot::game_bot>>& bots,
-                                       int                                                    max_hp,
-                                       int                                                    max_mp,
-                                       std::optional<int>                                     current_hp = std::nullopt,
-                                       std::optional<int>                                     current_mp = std::nullopt,
-                                       std::chrono::milliseconds                              timeout    = 5s);
+    async::task<bool> setup_bot_stats(std::shared_ptr<fb::bot::game_bot> bot,
+                                      int                                max_hp,
+                                      int                                max_mp,
+                                      std::optional<int>                 current_hp,
+                                      std::optional<int>                 current_mp,
+                                      std::chrono::milliseconds          timeout);
 
     /**
      * @brief      Learns multiple spells for a bot
@@ -305,7 +397,7 @@ protected:
      */
     async::task<void> move_bot_back_to_position(std::shared_ptr<fb::bot::game_bot> bot,
                                                 const fb::model::point<uint16_t>&  original_position,
-                                                std::chrono::milliseconds          interval = 100ms);
+                                                const fb::model::timespan&         interval = 100ms);
 };
 
 } // namespace fb::bot::integration


### PR DESCRIPTION
- This PR merges the latest fix from the develop branch into release/latest.
- Removes a duplicated `on_hook_position` hook that was causing issues in the skill test scenario.