### PR TITLE
feat: enable Nagle algorithm for TCP optimization

### DIFF
--- a/include/fb/acceptor.h
+++ b/include/fb/acceptor.h
@@ -413,6 +413,7 @@ private:
                     throw std::runtime_error("cannot accept socket. acceptor is cleaning now.");
 
                 shared_socket_ptr->data(this->handle_accepted(*shared_socket_ptr));
+                shared_socket_ptr->set_option(boost::asio::ip::tcp::no_delay(false));
 
                 {
                     auto fd = shared_socket_ptr->fd();


### PR DESCRIPTION
## Changes

This PR enables the Nagle algorithm for TCP optimization to improve network efficiency.

### What's Changed
- Add TCP_NODELAY(false) option to socket creation
- Enable packet buffering at TCP level for better network efficiency  
- Reduce network overhead by batching small packets
- Improve performance for multi-packet scenarios

### Technical Details
- Modified \include/fb/acceptor.h\ to configure TCP socket options
- This change allows the TCP stack to buffer small packets and send them together
- Should reduce the number of small packets sent over the network

### Files Modified
- \include/fb/acceptor.h\ (1 insertion)

### Commit
- dedeec3e: feat: enable Nagle algorithm for TCP optimization