### PR TITLE
feat: improve socket buffer size and fd handling

### DIFF
--- a/include/fb/socket.h
+++ b/include/fb/socket.h
@@ -22,7 +22,7 @@ template <typename T = void*>
 class socket : public boost::asio::ip::tcp::socket, public thread_switchable
 {
 public:
-    static constexpr uint32_t MAX_BUFFER_SIZE = 256;
+    static constexpr uint32_t MAX_BUFFER_SIZE = 4096;
 
 public:
     using handle_read_event = std::function<async::task<void>(fb::socket<T>&, fb::stream&)>;
@@ -90,6 +90,7 @@ public:
     };
 
 private:
+    mutable uint32_t    _fd = 0xFFFFFFFF;
     fb::async_executor& _executor;
     fb::encryption      _encryption;
     handle_read_event   _handle_received;
@@ -287,7 +288,11 @@ public:
 public:
     uint32_t fd() const
     {
-        return (uint32_t)const_cast<fb::socket<T>*>(this)->native_handle();
+        if (this->_fd != 0xFFFFFFFF)
+            return this->_fd;
+
+        this->_fd = (uint32_t)const_cast<fb::socket<T>*>(this)->native_handle();
+        return this->_fd;
     }
 
 public:


### PR DESCRIPTION
# Pull Request

## Title
feat: improve socket buffer size and fd handling

## Target Branch
origin/release/latest

## Description
This PR improves socket performance by increasing buffer size and implementing file descriptor caching.

### Changes
- Increase MAX_BUFFER_SIZE from 256 to 4096 for better performance
- Add _fd member variable for cached file descriptor
- Update fd() method to use cached _fd value when available

### Technical Details
- **Buffer Size**: Increased from 256 bytes to 4096 bytes to reduce I/O operations and improve throughput
- **FD Caching**: Added `_fd` member variable to cache the file descriptor value, avoiding repeated system calls
- **Performance**: The fd() method now returns cached value when available, improving performance for frequent fd() calls

### Files Changed
- `include/fb/socket.h`: Socket class improvements

### Related Issues
None

### Commit History
```
c82ec8ae feat: improve socket buffer size and fd handling
```
