### PR TITLE
fix: resolve compilation errors in health API endpoints

### DIFF
--- a/server/log/Program.cs
+++ b/server/log/Program.cs
@@ -1,10 +1,11 @@
-using Dapper;
 using Http.Service;
 using Log.Repository;
 using Log.Worker;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Log
@@ -55,12 +56,12 @@ namespace Log
                 // Health check endpoints
                 app.MapGet("/health/ready", (Http.Service.HealthCheckService health) =>
                 {
-                    return health.IsReady ? Results.Ok("Ready") : Results.ServiceUnavailable();
+                    return health.IsReady ? Results.Ok("Ready") : Results.StatusCode(503);
                 });
 
                 app.MapGet("/health/live", (Http.Service.HealthCheckService health) =>
                 {
-                    return health.IsAlive ? Results.Ok("Alive") : Results.ServiceUnavailable();
+                    return health.IsAlive ? Results.Ok("Alive") : Results.StatusCode(503);
                 });
             }
 

--- a/server/write-back/Program.cs
+++ b/server/write-back/Program.cs
@@ -1,8 +1,9 @@
 ﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Http.Service;
 
 namespace WriteBack
 {
@@ -21,13 +22,13 @@ namespace WriteBack
         static async Task Main(string[] args)
         {
             var builder = WebApplication.CreateBuilder(args);
-            
+
             // Add services
             builder.Services.AddSingleton<Http.Service.RedisService>();
             builder.Services.AddSingleton<Http.Service.DbContext>();
             builder.Services.AddSingleton<Http.Service.HealthCheckService>();
             builder.Logging.AddConsole();
-            builder.Services.AddHostedService<WriteBackService>();
+            builder.Services.AddHostedService<WriteBack.Service.WriteBackService>();
             builder.Services.AddHostedService<Http.Service.ShutdownListenerService>();
 
             // Read HealthApi configuration
@@ -50,12 +51,12 @@ namespace WriteBack
                 // Health check endpoints
                 app.MapGet("/health/ready", (Http.Service.HealthCheckService health) =>
                 {
-                    return health.IsReady ? Results.Ok("Ready") : Results.ServiceUnavailable();
+                    return health.IsReady ? Results.Ok("Ready") : Results.StatusCode(503);
                 });
 
                 app.MapGet("/health/live", (Http.Service.HealthCheckService health) =>
                 {
-                    return health.IsAlive ? Results.Ok("Alive") : Results.ServiceUnavailable();
+                    return health.IsAlive ? Results.Ok("Alive") : Results.StatusCode(503);
                 });
             }
 


### PR DESCRIPTION
## Changes

This PR fixes compilation errors in the health API endpoints for write-back and log services.

### Fixes
- Add missing using directives (Microsoft.AspNetCore.Http, Microsoft.Extensions.Configuration)
- Replace Results.ServiceUnavailable() with Results.StatusCode(503) for .NET 8 compatibility
- Fix WriteBackService namespace reference

## Commits
- fix: resolve compilation errors in health API endpoints