### PR TITLE
feat: add async lock retry mechanism and optimize thread routing

### DIFF
--- a/include/fb/amqp/queue.h
+++ b/include/fb/amqp/queue.h
@@ -5,6 +5,7 @@
 #include <fb/stream_reader.h>
 #include <functional>
 #include <async/task.h>
+#include <fb/thread_container.h>
 
 namespace fb::amqp {
 
@@ -18,16 +19,17 @@ public:
     using handle_container = std::unordered_map<uint32_t, handle_func>;
 
 private:
-    socket&          _owner;
-    handle_container _handler;
-    amqp_bytes_t     _raw_name;
-    std::string      _name;
-    amqp_bytes_t     _raw_tag;
-    std::string      _tag;
-    std::string      _route;
+    socket&               _owner;
+    handle_container      _handler;
+    amqp_bytes_t          _raw_name;
+    std::string           _name;
+    amqp_bytes_t          _raw_tag;
+    std::string           _tag;
+    std::string           _route;
+    fb::thread_container& _threads;
 
 private:
-    queue(socket& owner, const amqp_bytes_t& name);
+    queue(socket& owner, const amqp_bytes_t& name, fb::thread_container& threads);
     queue(const queue&) = delete;
 
 public:
@@ -39,6 +41,7 @@ public:
     const std::string&              route() const;
     const std::string&              consumer_tag() const;
     [[nodiscard]] async::task<void> invoke(const std::vector<uint8_t>& message);
+    void                            invoke_async(const std::vector<uint8_t>& message);
 
     template <typename R>
     void handler(const std::function<async::task<void>(R&)>& fn)

--- a/include/fb/amqp/socket.h
+++ b/include/fb/amqp/socket.h
@@ -13,6 +13,7 @@
 #include <rabbitmq-c/amqp.h>
 #include <rabbitmq-c/tcp_socket.h>
 #include <async/awaitable_then.h>
+#include <fb/thread_container.h>
 
 namespace fb::amqp {
 class queue;
@@ -32,7 +33,7 @@ public:
 public:
     bool connect(const std::string& hostname, uint16_t port, const std::string& id, const std::string& pw, const std::string& vhost);
 
-    queue& declare_queue(bool durable = true, bool exclusive = false, bool auto_delete = false, bool quorum = false);
+    queue& declare_queue(bool durable, bool exclusive, bool auto_delete, bool quorum, fb::thread_container& threads);
 
     bool select(const timeval* timeout = nullptr);
 

--- a/include/fb/amqp_handler_registry.h
+++ b/include/fb/amqp_handler_registry.h
@@ -125,7 +125,7 @@ public:
         try
         {
             // Declare queue with auto-generated name and bind with specified route key
-            auto& queue = this->_amqp->declare_queue(true, false, false, false);
+            auto& queue = this->_amqp->declare_queue(true, false, false, false, this->_owner.threads);
             queue.bind(exchange, route_key);
 
             auto& route = queue.route();

--- a/include/fb/game/character.h
+++ b/include/fb/game/character.h
@@ -284,6 +284,9 @@ public:
     async::task<void> foreach_async(character_async_function_t&& fn, const std::vector<character_ptr_t>& characters);
     async::task<void> foreach (const std::vector<std::string>& names, character_function_t && fn, character_function_t_miss miss = nullptr);
     async::task<void> foreach_async(const std::vector<std::string>& names, character_async_function_t&& fn, character_function_t_miss miss = nullptr);
+    void              foreach_enqueue(character_async_function_t&& fn, character_predicate_t predict = nullptr);
+    void              foreach_enqueue(character_async_function_t&& fn, const std::vector<character_ptr_t>& characters);
+    void              foreach_enqueue(const std::vector<std::string>& names, character_async_function_t&& fn, character_function_t_miss miss = nullptr);
     async::task<void> invoke(const std::string& name, character_function_t fn, character_function_t_miss miss = nullptr);
     async::task<void> invoke_async(const std::string& name, character_async_function_t fn, character_function_t_miss miss = nullptr);
 

--- a/include/fb/locker.h
+++ b/include/fb/locker.h
@@ -137,6 +137,26 @@ public:
         }
     }
 
+    bool try_lock_shared()
+    {
+        if (!this->_writer.load(std::memory_order_acquire) && this->writer_queue_empty())
+        {
+            this->_reader_count.fetch_add(1, std::memory_order_relaxed);
+            return true;
+        }
+        return false;
+    }
+
+    bool try_lock()
+    {
+        auto expected = false;
+        if (this->_reader_count.load(std::memory_order_acquire) == 0 && this->_writer.compare_exchange_strong(expected, true, std::memory_order_acq_rel))
+        {
+            return true;
+        }
+        return false;
+    }
+
 private:
     std::atomic<int>                                                 _reader_count{0};
     std::atomic<bool>                                                _writer{false};
@@ -245,6 +265,74 @@ public:
                 auto result = co_await (*func_holder)(this->_value);
                 this->_async_mutex.unlock();
                 co_return result;
+            }
+        }
+        catch (...)
+        {
+            this->_async_mutex.unlock();
+            throw;
+        }
+    }
+
+    template <typename Func> auto try_async_read(Func&& fn) const -> async::task<bool>
+    {
+        // Create shared_ptr holder to ensure function lifetime safety
+        auto func_holder = std::make_shared<std::decay_t<Func>>(std::forward<Func>(fn));
+
+        if (!this->_async_mutex.try_lock_shared())
+        {
+            co_return false;
+        }
+
+        std::shared_lock lock(this->_sync_mutex);
+
+        try
+        {
+            if constexpr (std::is_same_v<decltype((*func_holder)(this->_value)), async::task<void>>)
+            {
+                co_await (*func_holder)(this->_value);
+                this->_async_mutex.unlock_shared();
+                co_return true;
+            }
+            else
+            {
+                co_await (*func_holder)(this->_value);
+                this->_async_mutex.unlock_shared();
+                co_return true;
+            }
+        }
+        catch (...)
+        {
+            this->_async_mutex.unlock_shared();
+            throw;
+        }
+    }
+
+    template <typename Func> auto try_async_write(Func&& fn) -> async::task<bool>
+    {
+        // Create shared_ptr holder to ensure function lifetime safety
+        auto func_holder = std::make_shared<std::decay_t<Func>>(std::forward<Func>(fn));
+
+        if (!this->_async_mutex.try_lock())
+        {
+            co_return false;
+        }
+
+        std::unique_lock lock(this->_sync_mutex);
+
+        try
+        {
+            if constexpr (std::is_same_v<decltype((*func_holder)(this->_value)), async::task<void>>)
+            {
+                co_await (*func_holder)(this->_value);
+                this->_async_mutex.unlock();
+                co_return true;
+            }
+            else
+            {
+                co_await (*func_holder)(this->_value);
+                this->_async_mutex.unlock();
+                co_return true;
             }
         }
         catch (...)

--- a/include/fb/shard_container.h
+++ b/include/fb/shard_container.h
@@ -165,15 +165,41 @@ public:
         });
     }
 
-    bool erase(HashType hash)
+    template <typename Callback = std::nullptr_t>
+    bool erase(HashType hash, Callback&& callback = nullptr)
     {
-        return this->_data.write([&](map_type& data) {
-            if (!data.contains(hash))
-                return false;
+        if constexpr (std::is_same_v<std::decay_t<Callback>, std::nullptr_t>)
+        {
+            // No callback version
+            return this->_data.write([&](map_type& data) {
+                if (!data.contains(hash))
+                    return false;
 
-            data.erase(hash);
-            return true;
-        });
+                data.erase(hash);
+                return true;
+            });
+        }
+        else
+        {
+            // With callback version - callback receives the element before erasure
+            // Callback signature: (const T&) -> void
+            auto callback_holder = std::make_shared<std::decay_t<Callback>>(std::forward<Callback>(callback));
+
+            return this->_data.write([hash, callback_holder](map_type& data) {
+                if (!data.contains(hash))
+                    return false;
+
+                // Get reference to element before erasure
+                const auto& element = data.at(hash);
+
+                // Call callback with element before erasing
+                (*callback_holder)(element);
+
+                // Erase after callback
+                data.erase(hash);
+                return true;
+            });
+        }
     }
 
     template <typename Callback = std::nullptr_t>
@@ -350,6 +376,92 @@ public:
         }
     }
 
+    template <typename Func>
+    auto try_async_read(HashType hash, Func&& func) const -> async::task<bool>
+    {
+        auto func_holder = std::make_shared<std::decay_t<Func>>(std::forward<Func>(func));
+
+        return this->_data.try_async_read([hash, func_holder](const map_type& data) mutable -> async::task<void> {
+            if (!data.contains(hash))
+                throw std::runtime_error("Element not found");
+
+            co_await (*func_holder)(data.at(hash));
+        });
+    }
+
+    template <typename Func>
+    auto try_async_write(HashType hash, Func&& func) -> async::task<bool>
+    {
+        auto func_holder = std::make_shared<std::decay_t<Func>>(std::forward<Func>(func));
+
+        return this->_data.try_async_write([hash, func_holder](map_type& data) mutable -> async::task<void> {
+            if (!data.contains(hash))
+                throw std::runtime_error("Element not found");
+
+            co_await (*func_holder)(data.at(hash));
+        });
+    }
+
+    template <typename Func, typename Factory>
+    auto try_async_write(HashType hash, Func&& func, Factory&& factory) -> async::task<bool>
+    {
+        using task_type = decltype(func(std::declval<T&>()));
+
+        auto func_holder    = std::make_shared<std::decay_t<Func>>(std::forward<Func>(func));
+        auto factory_holder = std::make_shared<std::decay_t<Factory>>(std::forward<Factory>(factory));
+
+        if constexpr (std::is_same_v<task_type, async::task<void>>)
+        {
+            return this->_data.try_async_write([hash, func_holder, factory_holder](map_type& data) mutable -> async::task<void> {
+                if (!data.contains(hash))
+                {
+                    // Create element using factory
+                    if constexpr (std::is_invocable_r_v<T, Factory>)
+                    {
+                        // Regular function returning T
+                        data.insert(hash, (*factory_holder)());
+                    }
+                    else if constexpr (std::is_invocable_r_v<async::task<T>, Factory>)
+                    {
+                        // Coroutine function returning async::task<T>
+                        data.insert(hash, co_await (*factory_holder)());
+                    }
+                    else
+                    {
+                        static_assert(std::is_invocable_r_v<T, Factory> || std::is_invocable_r_v<async::task<T>, Factory>, "Factory must return T or async::task<T>");
+                    }
+                }
+
+                co_await (*func_holder)(data.at(hash));
+            });
+        }
+        else
+        {
+            return this->_data.try_async_write([hash, func_holder, factory_holder](map_type& data) mutable -> async::task<void> {
+                if (!data.contains(hash))
+                {
+                    // Create element using factory
+                    if constexpr (std::is_invocable_r_v<T, Factory>)
+                    {
+                        // Regular function returning T
+                        data.insert(hash, (*factory_holder)());
+                    }
+                    else if constexpr (std::is_invocable_r_v<async::task<T>, Factory>)
+                    {
+                        // Coroutine function returning async::task<T>
+                        data.insert(hash, co_await (*factory_holder)());
+                    }
+                    else
+                    {
+                        static_assert(std::is_invocable_r_v<T, Factory> || std::is_invocable_r_v<async::task<T>, Factory>, "Factory must return T or async::task<T>");
+                    }
+                }
+
+                co_await (*func_holder)(data.at(hash));
+            });
+        }
+    }
+
     template <typename Func, typename Factory>
     auto async_write(HashType hash, Func&& func, Factory&& factory)
     {
@@ -445,9 +557,10 @@ public:
         return this->bucket(hash)->insert(hash, value);
     }
 
-    bool erase(HashType hash)
+    template <typename Callback = std::nullptr_t>
+    bool erase(HashType hash, Callback&& callback = nullptr)
     {
-        return this->bucket(hash)->erase(hash);
+        return this->bucket(hash)->erase(hash, std::forward<Callback>(callback));
     }
 
     template <typename Callback = std::nullptr_t>
@@ -490,6 +603,24 @@ public:
     auto async_write(HashType hash, Func&& func, Factory&& factory)
     {
         return this->bucket(hash)->async_write(hash, std::forward<Func>(func), std::forward<Factory>(factory));
+    }
+
+    template <typename Func>
+    auto try_async_read(HashType hash, Func&& func) const -> async::task<bool>
+    {
+        return this->bucket(hash)->try_async_read(hash, std::forward<Func>(func));
+    }
+
+    template <typename Func>
+    auto try_async_write(HashType hash, Func&& func) -> async::task<bool>
+    {
+        return this->bucket(hash)->try_async_write(hash, std::forward<Func>(func));
+    }
+
+    template <typename Func, typename Factory>
+    auto try_async_write(HashType hash, Func&& func, Factory&& factory) -> async::task<bool>
+    {
+        return this->bucket(hash)->try_async_write(hash, std::forward<Func>(func), std::forward<Factory>(factory));
     }
 
 private:

--- a/include/fb/thread.h
+++ b/include/fb/thread.h
@@ -128,6 +128,7 @@ public:
 
     [[nodiscard]] async::task<void> dispatch(const handle_func_type<void>& fn);
     [[nodiscard]] async::task<void> switching();
+    size_t                          queue_size() const;
 };
 
 } // namespace fb

--- a/include/fb/thread.h
+++ b/include/fb/thread.h
@@ -129,6 +129,79 @@ public:
     [[nodiscard]] async::task<void> dispatch(const handle_func_type<void>& fn);
     [[nodiscard]] async::task<void> switching();
     size_t                          queue_size() const;
+    std::string                     to_string() const;
+
+    template <typename RetryFunc>
+    async::task<bool> enqueue_with_retry(
+        RetryFunc&&              fn,
+        size_t                   max_retries = 10,
+        const handle_error_type& error       = [](std::exception& e) {
+        })
+    {
+        static_assert(std::is_same_v<decltype(fn(*this)), async::task<bool>>, "RetryFunc must return async::task<bool>");
+
+        auto           promise     = std::make_shared<async::task_completion_source<bool>>();
+        auto           retry_count = std::make_shared<size_t>(0);
+        constexpr auto retry_delay = 100ms;
+
+        auto retry_func = std::make_shared<std::function<void()>>();
+        *retry_func     = [=, this]() mutable {
+            async::awaitable_then(fn(*this), [=, this](async::awaitable_result<bool> result) mutable {
+                try
+                {
+                    auto success = result();
+                    if (success)
+                    {
+                        promise->set_value(true);
+                    }
+                    else if (*retry_count < max_retries)
+                    {
+                        (*retry_count)++;
+                        // Sleep before retry
+                        async::awaitable_then(this->sleep(retry_delay), [=, this](async::awaitable_result<void> sleep_result) {
+                            try
+                            {
+                                sleep_result();
+                                // Re-enqueue after sleep
+                                this->_queue.write([retry_func](auto& queue) {
+                                    queue.push(*retry_func);
+                                });
+                            }
+                            catch (std::exception& e)
+                            {
+                                error(e);
+                                promise->set_exception(std::make_exception_ptr(e));
+                            }
+                            catch (...)
+                            {
+                                promise->set_exception(std::make_exception_ptr(std::runtime_error("unknown error")));
+                            }
+                        });
+                    }
+                    else
+                    {
+                        promise->set_value(false); // Max retries exceeded
+                    }
+                }
+                catch (std::exception& e)
+                {
+                    error(e);
+                    promise->set_exception(std::make_exception_ptr(e));
+                }
+                catch (...)
+                {
+                    promise->set_exception(std::make_exception_ptr(std::runtime_error("unknown error")));
+                }
+            });
+        };
+
+        // First attempt
+        this->_queue.write([retry_func](auto& queue) {
+            queue.push(*retry_func);
+        });
+
+        return promise->task();
+    }
 };
 
 } // namespace fb

--- a/include/fb/thread_container.h
+++ b/include/fb/thread_container.h
@@ -19,7 +19,7 @@ public:
 
 private:
     fb::async_executor&     _executor;
-    unique_thread_container _thread_container;
+    unique_thread_container _logic_threads;
     unique_id_list          _keys;
 
 public:
@@ -332,8 +332,9 @@ public:
         });
     }
 
-    void settimer(const fb::timer::handle_callback_type& fn, const fb::model::timespan& duration);
-    void exit();
+    void        settimer(const fb::timer::handle_callback_type& fn, const fb::model::timespan& duration);
+    void        exit();
+    fb::thread* least_loaded() const;
 
 public:
     iterator       begin();

--- a/infra/pulumi/rabbitmq.js
+++ b/infra/pulumi/rabbitmq.js
@@ -134,73 +134,73 @@ cluster_partition_handling = autoheal
 export RABBITMQ_NODENAME=rabbit@$MY_POD_NAME.${headlessServiceName}.$MY_POD_NAMESPACE.svc.cluster.local
 exec docker-entrypoint.sh rabbitmq-server
 `],
-                                    volumeMounts: [
-                                        { name: "config", mountPath: "/etc/rabbitmq" }
-                                    ],
-                                            readinessProbe: {
-                                                exec: { command: ["rabbitmq-diagnostics", "ping"] },
-                                                initialDelaySeconds: 20,
-                                                periodSeconds: 10,
-                                                timeoutSeconds: 5,
-                                            },
-                                            livenessProbe: {
-                                                exec: { command: ["rabbitmq-diagnostics", "ping"] },
-                                                initialDelaySeconds: 60,
-                                                periodSeconds: 30,
-                                                timeoutSeconds: 10,
-                                            },
-                                }],
-                                volumes: [
-                                    {
-                                        name: "config",
-                                        configMap: { name: configMap.metadata.name }
-                                    }
-                                ]
+                                        volumeMounts: [
+                                            { name: "config", mountPath: "/etc/rabbitmq" }
+                                        ],
+                                        readinessProbe: {
+                                            exec: { command: ["rabbitmq-diagnostics", "ping"] },
+                                            initialDelaySeconds: 20,
+                                            periodSeconds: 10,
+                                            timeoutSeconds: 5,
+                                        },
+                                        livenessProbe: {
+                                            exec: { command: ["rabbitmq-diagnostics", "ping"] },
+                                            initialDelaySeconds: 60,
+                                            periodSeconds: 30,
+                                            timeoutSeconds: 10,
+                                        },
+                                    }],
+                                    volumes: [
+                                        {
+                                            name: "config",
+                                            configMap: { name: configMap.metadata.name }
+                                        }
+                                    ]
+                                }
                             }
-                        }
-                    },
-                }, { dependsOn: [headlessService, configMap, serviceAccount, roleBinding] })
-                        
-                        // Create ClusterIP service
-                        const clusterIPService = new k8s.core.v1.Service(resourceName, {
-                            metadata: { name: resourceName, namespace: namespace.metadata.name },
-                            spec: {
-                                type: "ClusterIP",
-                                selector: { app: "rabbitmq", section: section, type: type },
-                                ports: [
-                                    { name: "amqp", port: typeConf.port.amqp.cluster, targetPort: 5672 },
-                                    { name: "management", port: typeConf.port.management.cluster, targetPort: 15672 },
-                                ],
-                            },
-                        }, { dependsOn: [statefulSet] });
-                        
-                        // Create NodePort service
-                        const nodeportService = new k8s.core.v1.Service(`${resourceName}-nodeport`, {
-                            metadata: { name: `${resourceName}-nodeport`, namespace: namespace.metadata.name },
-                            spec: {
-                                type: "NodePort",
-                                selector: { app: "rabbitmq", section: section, type: type },
-                                ports: [
-                                    {
-                                        name: "amqp",
-                                        port: typeConf.port.amqp.cluster,
-                                        targetPort: 5672,
-                                        nodePort: typeConf.port.amqp.node,
-                                    },
-                                    {
-                                        name: "management",
-                                        port: typeConf.port.management.cluster,
-                                        targetPort: 15672,
-                                        nodePort: typeConf.port.management.node,
-                                    },
-                                ],
-                            },
-                        }, { dependsOn: [statefulSet] });
-                        
-                        resources.push(configMap, headlessService, statefulSet, clusterIPService, nodeportService)
-                    }
+                        },
+                    }, { dependsOn: [headlessService, configMap, serviceAccount, roleBinding] })
+                    
+                    // Create ClusterIP service
+                    const clusterIPService = new k8s.core.v1.Service(resourceName, {
+                        metadata: { name: resourceName, namespace: namespace.metadata.name },
+                        spec: {
+                            type: "ClusterIP",
+                            selector: { app: "rabbitmq", section: section, type: type },
+                            ports: [
+                                { name: "amqp", port: typeConf.port.amqp.cluster, targetPort: 5672 },
+                                { name: "management", port: typeConf.port.management.cluster, targetPort: 15672 },
+                            ],
+                        },
+                    }, { dependsOn: [statefulSet] });
+                    
+                    // Create NodePort service
+                    const nodeportService = new k8s.core.v1.Service(`${resourceName}-nodeport`, {
+                        metadata: { name: `${resourceName}-nodeport`, namespace: namespace.metadata.name },
+                        spec: {
+                            type: "NodePort",
+                            selector: { app: "rabbitmq", section: section, type: type },
+                            ports: [
+                                {
+                                    name: "amqp",
+                                    port: typeConf.port.amqp.cluster,
+                                    targetPort: 5672,
+                                    nodePort: typeConf.port.amqp.node,
+                                },
+                                {
+                                    name: "management",
+                                    port: typeConf.port.management.cluster,
+                                    targetPort: 15672,
+                                    nodePort: typeConf.port.management.node,
+                                },
+                            ],
+                        },
+                    }, { dependsOn: [statefulSet] });
+                    
+                    resources.push(configMap, headlessService, statefulSet, clusterIPService, nodeportService)
                 }
-                
-                return resources
             }
+            
+            return resources
         }
+    }

--- a/server/fb/src/amqp.queue.cpp
+++ b/server/fb/src/amqp.queue.cpp
@@ -2,9 +2,10 @@
 
 using namespace fb::amqp;
 
-queue::queue(socket& owner, const amqp_bytes_t& name) :
+queue::queue(socket& owner, const amqp_bytes_t& name, fb::thread_container& threads) :
     _owner(owner),
-    _raw_name(name)
+    _raw_name(name),
+    _threads(threads)
 { }
 
 queue::~queue()
@@ -18,16 +19,10 @@ queue::~queue()
 
 bool queue::bind(const std::string& exchange, const std::string& route)
 {
-    amqp_queue_bind(this->_owner,
-                    1,
-                    this->_raw_name,
-                    amqp_cstring_bytes(exchange.c_str()),
-                    amqp_cstring_bytes(route.c_str()),
-                    amqp_empty_table);
+    amqp_queue_bind(this->_owner, 1, this->_raw_name, amqp_cstring_bytes(exchange.c_str()), amqp_cstring_bytes(route.c_str()), amqp_empty_table);
     if (amqp_get_rpc_reply(this->_owner).reply_type != AMQP_RESPONSE_NORMAL)
         return false;
-    this->_name =
-        std::string((const char*)this->_raw_name.bytes, (const char*)this->_raw_name.bytes + this->_raw_name.len);
+    this->_name = std::string((const char*)this->_raw_name.bytes, (const char*)this->_raw_name.bytes + this->_raw_name.len);
 
     auto r = amqp_basic_consume(this->_owner, 1, this->_raw_name, amqp_empty_bytes, 0, 1, 0, amqp_empty_table);
     if (amqp_get_rpc_reply(this->_owner).reply_type != AMQP_RESPONSE_NORMAL)
@@ -68,6 +63,44 @@ async::task<void> queue::invoke(const std::vector<uint8_t>& message)
         co_return;
 
     co_await found->second(((const uint8_t*)stream.data()) + (sizeof(uint32_t) * 2));
+}
+
+void queue::invoke_async(const std::vector<uint8_t>& message)
+{
+    auto target_thread = this->_threads.least_loaded();
+    if (target_thread == nullptr)
+    {
+        // Fallback to synchronous invoke if no thread available
+        async::awaitable_then(this->invoke(message), [](async::awaitable_result<void> result) {
+            // work done
+            try
+            {
+                result();
+            }
+            catch (std::exception& e)
+            {
+                fb::logger::fatal("AMQP message processing error: {}", e.what());
+            }
+            catch (...)
+            {
+                fb::logger::fatal("AMQP message processing error: unknown error");
+            }
+        });
+    }
+    else
+    {
+        // Enqueue to the least loaded thread
+        target_thread->enqueue(
+            [message, this](auto& thread) -> async::task<void> {
+                co_await this->invoke(message);
+            },
+            [](std::exception& e) {
+                fb::logger::fatal("AMQP message processing error: {}", e.what());
+            },
+            []() {
+                // work done
+            });
+    }
 }
 
 void queue::handler(uint32_t cmd, const handle_func& fn)

--- a/server/fb/src/amqp.socket.cpp
+++ b/server/fb/src/amqp.socket.cpp
@@ -66,7 +66,7 @@ bool socket::connect(const std::string& hostname, uint16_t port, const std::stri
     return true;
 }
 
-queue& socket::declare_queue(bool durable, bool exclusive, bool auto_delete, bool quorum)
+queue& socket::declare_queue(bool durable, bool exclusive, bool auto_delete, bool quorum, fb::thread_container& threads)
 {
     amqp_table_t arguments = amqp_empty_table;
 
@@ -110,7 +110,7 @@ queue& socket::declare_queue(bool durable, bool exclusive, bool auto_delete, boo
     if (name.bytes == nullptr)
         throw std::runtime_error("Out of memory while copying queue name");
 
-    auto ptr = new queue(*this, name);
+    auto ptr = new queue(*this, name, threads);
     this->_queues.push_back(std::unique_ptr<queue>(ptr));
 
     return *ptr;
@@ -173,9 +173,7 @@ bool socket::select(const timeval* timeout)
             if (queue->consumer_tag() == consumer_tag)
             {
                 auto message = std::vector<uint8_t>((uint8_t*)envelope.message.body.bytes, (uint8_t*)envelope.message.body.bytes + envelope.message.body.len);
-                async::awaitable_then(queue->invoke(message), [](async::awaitable_result<void> result) {
-                    // work done
-                });
+                queue->invoke_async(message);
                 break;
             }
         }

--- a/server/fb/src/thread.cpp
+++ b/server/fb/src/thread.cpp
@@ -214,3 +214,10 @@ uint8_t fb::thread::index() const
 {
     return this->_index;
 }
+
+size_t fb::thread::queue_size() const
+{
+    return this->_queue.read([](const auto& queue) -> size_t {
+        return queue.size();
+    });
+}

--- a/server/fb/src/thread.cpp
+++ b/server/fb/src/thread.cpp
@@ -1,4 +1,5 @@
 #include <fb/thread.h>
+#include <sstream>
 
 fb::thread::thread(uint8_t index) :
     _index(index)
@@ -220,4 +221,11 @@ size_t fb::thread::queue_size() const
     return this->_queue.read([](const auto& queue) -> size_t {
         return queue.size();
     });
+}
+
+std::string fb::thread::to_string() const
+{
+    std::ostringstream oss;
+    oss << "thread[" << static_cast<int>(this->_index) << ":" << this->_thread.get_id() << "]";
+    return oss.str();
 }

--- a/server/fb/src/thread_container.cpp
+++ b/server/fb/src/thread_container.cpp
@@ -14,7 +14,7 @@ thread_container::thread_container(fb::async_executor& executor, uint32_t count)
         auto ptr       = std::make_unique<thread>(i);
         auto id        = ptr->id();
         this->_keys[i] = id;
-        this->_thread_container.insert({id, std::move(ptr)});
+        this->_logic_threads.insert({id, std::move(ptr)});
     }
 }
 
@@ -22,7 +22,7 @@ thread_container::~thread_container()
 {
     if (this->deletor)
     {
-        for (auto& [id, thread] : this->_thread_container)
+        for (auto& [id, thread] : this->_logic_threads)
         {
             if (thread == nullptr)
                 continue;
@@ -31,7 +31,7 @@ thread_container::~thread_container()
         }
     }
 
-    for (auto& [id, thread] : this->_thread_container)
+    for (auto& [id, thread] : this->_logic_threads)
     {
         thread->exit();
         thread->join();
@@ -40,10 +40,10 @@ thread_container::~thread_container()
 
 thread* thread_container::at(uint8_t index) const
 {
-    if (this->_thread_container.size() == 0)
+    if (this->_logic_threads.size() == 0)
         return nullptr;
 
-    if (index > this->_thread_container.size() - 1)
+    if (index > this->_logic_threads.size() - 1)
         return nullptr;
 
     auto& id = this->_keys[index];
@@ -52,8 +52,8 @@ thread* thread_container::at(uint8_t index) const
 
 thread* thread_container::at(std::thread::id id) const
 {
-    auto found = this->_thread_container.find(id);
-    if (found == this->_thread_container.end())
+    auto found = this->_logic_threads.find(id);
+    if (found == this->_logic_threads.end())
         return nullptr;
     else
         return found->second.get();
@@ -61,7 +61,7 @@ thread* thread_container::at(std::thread::id id) const
 
 thread* thread_container::modular(uint32_t id) const
 {
-    if (this->_thread_container.size() == 0)
+    if (this->_logic_threads.size() == 0)
         return nullptr;
 
     auto index = id % this->size();
@@ -71,8 +71,8 @@ thread* thread_container::modular(uint32_t id) const
 thread* thread_container::current()
 {
     auto id    = std::this_thread::get_id();
-    auto found = this->_thread_container.find(id);
-    if (found == this->_thread_container.end())
+    auto found = this->_logic_threads.find(id);
+    if (found == this->_logic_threads.end())
         return nullptr;
     else
         return found->second.get();
@@ -81,8 +81,8 @@ thread* thread_container::current()
 const thread* thread_container::current() const
 {
     auto id    = std::this_thread::get_id();
-    auto found = this->_thread_container.find(id);
-    if (found == this->_thread_container.end())
+    auto found = this->_logic_threads.find(id);
+    if (found == this->_logic_threads.end())
         return nullptr;
     else
         return found->second.get();
@@ -90,12 +90,12 @@ const thread* thread_container::current() const
 
 uint8_t thread_container::count() const
 {
-    return (uint8_t)this->_thread_container.size();
+    return (uint8_t)this->_logic_threads.size();
 }
 
 bool thread_container::empty() const
 {
-    return this->_thread_container.size() == 0;
+    return this->_logic_threads.size() == 0;
 }
 
 bool thread_container::valid(uint8_t index) const
@@ -124,18 +124,18 @@ bool thread_container::valid(thread* thread) const
 
 size_t thread_container::size() const
 {
-    return this->_thread_container.size();
+    return this->_logic_threads.size();
 }
 
 void thread_container::settimer(const fb::timer::handle_callback_type& fn, const fb::model::timespan& duration)
 {
-    if (this->_thread_container.empty())
+    if (this->_logic_threads.empty())
     {
         throw std::runtime_error("cannot set timer. logic thread does not exists");
     }
     else
     {
-        for (auto& [key, thread] : this->_thread_container)
+        for (auto& [key, thread] : this->_logic_threads)
         {
             std::ignore = thread->dispatch([fn, duration](auto& thread) -> async::task<void> {
                 thread.settimer(fn, duration);
@@ -147,10 +147,31 @@ void thread_container::settimer(const fb::timer::handle_callback_type& fn, const
 
 void thread_container::exit()
 {
-    for (auto& [id, thread] : this->_thread_container)
+    for (auto& [id, thread] : this->_logic_threads)
     {
         thread->exit();
     }
+}
+
+thread* thread_container::least_loaded() const
+{
+    if (this->_logic_threads.empty())
+        return nullptr;
+
+    thread* result   = nullptr;
+    size_t  min_size = SIZE_MAX;
+
+    for (auto& [id, thread] : this->_logic_threads)
+    {
+        auto size = thread->queue_size();
+        if (size < min_size)
+        {
+            min_size = size;
+            result   = thread.get();
+        }
+    }
+
+    return result;
 }
 
 thread* thread_container::operator[] (uint8_t index) const
@@ -165,30 +186,30 @@ thread* thread_container::operator[] (std::thread::id id) const
 
 thread_container::iterator thread_container::begin()
 {
-    return this->_thread_container.begin();
+    return this->_logic_threads.begin();
 }
 
 thread_container::iterator thread_container::end()
 {
-    return this->_thread_container.end();
+    return this->_logic_threads.end();
 }
 
 thread_container::const_iterator thread_container::begin() const
 {
-    return this->_thread_container.begin();
+    return this->_logic_threads.begin();
 }
 
 thread_container::const_iterator thread_container::end() const
 {
-    return this->_thread_container.end();
+    return this->_logic_threads.end();
 }
 
 thread_container::const_iterator thread_container::cbegin() const
 {
-    return this->_thread_container.cbegin();
+    return this->_logic_threads.cbegin();
 }
 
 thread_container::const_iterator thread_container::cend() const
 {
-    return this->_thread_container.cend();
+    return this->_logic_threads.cend();
 }

--- a/server/game/lib/object/character.container.cpp
+++ b/server/game/lib/object/character.container.cpp
@@ -177,6 +177,79 @@ async::task<void> character::container::invoke_async(const std::string& name, ch
         co_await before->switching();
 }
 
+void character::container::foreach_enqueue(character_async_function_t&& fn, const std::vector<character_ptr_t>& characters)
+{
+    auto group = std::unordered_map<fb::thread*, std::vector<std::weak_ptr<character>>>();
+
+    for (auto& ch : characters)
+    {
+        auto each_thread = ch->thread();
+        if (each_thread == nullptr)
+            continue;
+
+        auto weak_ptr = ch->weak_from_this_as<character>();
+        if (group.contains(each_thread) == false)
+            group[each_thread] = std::vector<std::weak_ptr<character>>();
+
+        group[each_thread].push_back(weak_ptr);
+    }
+
+    auto fn_holder = std::make_shared<character_async_function_t>(std::move(fn));
+    for (auto& [thread, weak_ptrs] : group)
+    {
+        thread->enqueue(
+            [fn_holder, weak_ptrs](auto& thread) -> async::task<void> {
+                for (auto& weak_ptr : weak_ptrs)
+                {
+                    auto shared_ptr = weak_ptr.lock();
+                    if (shared_ptr == nullptr)
+                        continue;
+
+                    co_await (*fn_holder)(shared_ptr);
+                }
+            },
+            [](std::exception& e) {
+                fb::logger::fatal("foreach_enqueue error: {}", e.what());
+            },
+            []() {
+                // work done
+            });
+    }
+}
+
+void character::container::foreach_enqueue(character_async_function_t&& fn, character_predicate_t predict)
+{
+    auto targets = std::vector<character_ptr_t>();
+    for (auto& [uid, ch] : this->_from_uid)
+    {
+        if (predict != nullptr && predict(ch) == false)
+            continue;
+
+        targets.push_back(ch);
+    }
+
+    this->foreach_enqueue(std::move(fn), std::move(targets));
+}
+
+void character::container::foreach_enqueue(const std::vector<std::string>& names, character_async_function_t&& fn, character_function_t_miss miss)
+{
+    auto targets = std::vector<character_ptr_t>();
+    for (auto& name : names)
+    {
+        auto ch = this->find(name);
+        if (ch == nullptr)
+        {
+            if (miss != nullptr)
+                miss(name);
+            continue;
+        }
+
+        targets.push_back(ch);
+    }
+
+    this->foreach_enqueue(std::move(fn), std::move(targets));
+}
+
 character::container::character_ptr_t character::container::operator[] (uint32_t uid)
 {
     auto ch = this->find(uid);

--- a/server/game/lib/object/character.cpp
+++ b/server/game/lib/object/character.cpp
@@ -90,6 +90,11 @@ async::task<bool> character::map(std::shared_ptr<fb::game::map> map, const fb::m
     auto switch_process = (map != nullptr && map->active == false);
     if (switch_process)
     {
+        // Store map information before on_transfer to avoid use-after-free
+        // on_transfer may cause thread switching and modify character state
+        auto new_map_id   = map != nullptr ? std::make_optional(map->model.id) : std::optional<uint32_t>();
+        auto new_position = position;
+
         auto result = co_await this->listener.on_transfer(*this, *map, position);
         if (result && old_map != map)
         {
@@ -104,11 +109,11 @@ async::task<bool> character::map(std::shared_ptr<fb::game::map> map, const fb::m
                 log_data["old_position_x"] = old_position.x;
                 log_data["old_position_y"] = old_position.y;
             }
-            if (map != nullptr)
+            if (new_map_id.has_value())
             {
-                log_data["new_map"]        = map->model.id;
-                log_data["new_position_x"] = position.x;
-                log_data["new_position_y"] = position.y;
+                log_data["new_map"]        = new_map_id.value();
+                log_data["new_position_x"] = new_position.x;
+                log_data["new_position_y"] = new_position.y;
             }
             this->server.log.write("map_transfer", log_data);
         }

--- a/server/game/lib/server/server.clan.cpp
+++ b/server/game/lib/server/server.clan.cpp
@@ -24,38 +24,52 @@ void server::assert_clan(uint32_t error) const
 async::task<void> server::ensure_clan(uint32_t id, std::function<async::task<void>(std::shared_ptr<fb::game::clan>&)> fn)
 {
     auto thread = this->threads.current();
-    co_await this->clans.async_write(
-        id,
-        [this, fn, thread](auto& clan) -> async::task<void> {
-            if (thread != nullptr)
-                co_await thread->switching();
+    if (thread == nullptr)
+    {
+        throw std::runtime_error(std::format("No thread available for ensure_clan (clan_id: {})", id));
+    }
 
-            co_await fn(clan);
+    // Use try_async_write with retry mechanism
+    // Note: We need to ensure we return to the original thread after try_async_write completes
+    auto success = co_await thread->enqueue_with_retry(
+        [=, this](auto& thread) -> async::task<bool> {
+            auto result = co_await this->clans.try_async_write(
+                id,
+                [this, fn, &thread](auto& clan) -> async::task<void> {
+                    co_await fn(clan);
+                    // Ensure we return to the original thread after fn completes
+                    co_await thread.switching();
+                },
+                [=, this]() -> async::task<std::shared_ptr<fb::game::clan>> {
+                    auto&& resp = co_await this->http.get<internal_resp::ClanDetails>("internal", std::format("/clan/{}", id));
+                    switch (static_cast<ERROR_CODE>(resp.error))
+                    {
+                    case ERROR_CODE::NONE:
+                    {
+                        auto members = std::unordered_map<std::string, clan_member>{};
+                        for (auto& member : resp.members)
+                        {
+                            members.insert({
+                                member.name,
+                                clan_member{member.name, static_cast<CLAN_ROLE>(member.role)}
+                            });
+                        }
+                        co_return std::make_shared<fb::game::clan>(*this, id, resp.clan.name, resp.clan.title, members);
+                    }
+
+                    default:
+                        throw std::runtime_error(std::format("cannot get clan (error : {})", resp.error));
+                    }
+                });
+            co_return result;
         },
-        [=, this]() -> async::task<std::shared_ptr<fb::game::clan>> {
-            auto&& resp = co_await this->http.get<internal_resp::ClanDetails>("internal", std::format("/clan/{}", id));
-            switch (static_cast<ERROR_CODE>(resp.error))
-            {
-            case ERROR_CODE::NONE:
-            {
-                auto members = std::unordered_map<std::string, clan_member>{};
-                for (auto& member : resp.members)
-                {
-                    members.insert({
-                        member.name,
-                        clan_member{member.name, static_cast<CLAN_ROLE>(member.role)}
-                    });
-                }
-                co_return std::make_shared<fb::game::clan>(*this, id, resp.clan.name, resp.clan.title, members);
-            }
+        10 // max_retries
+    );
 
-            default:
-                throw std::runtime_error(std::format("cannot get clan (error : {})", resp.error));
-            }
-        });
-
-    if (thread != nullptr)
-        co_await thread->switching();
+    if (!success)
+    {
+        throw std::runtime_error(std::format("Failed to acquire clan lock after retries (clan_id: {})", id));
+    }
 }
 
 void server::update_clan(clan& clan, fb::protocol::internal::Clan& resp1, const std::vector<fb::protocol::internal::ClanMember>& resp2) const
@@ -379,7 +393,7 @@ async::task<void> server::on_destroyed_clan(const internal_resp::DestroyClan& re
 
     // Atomic operation: read clan data, send message, and erase in one atomic block
     // async_erase callback receives the clan before erasure, and callback is only called if clan exists
-    co_await this->clans.async_erase(resp.clan_id, [this, &resp](const auto& clan) -> async::task<void> {
+    this->clans.erase(resp.clan_id, [this, &resp](const auto& clan) {
         auto members = std::vector<std::shared_ptr<fb::game::character>>();
         for (auto& [_, weak_ptr] : clan->characters())
         {
@@ -390,16 +404,18 @@ async::task<void> server::on_destroyed_clan(const internal_resp::DestroyClan& re
         }
 
         auto message = std::format(_TEXT(MESSAGE_CLAN_DISBANDED), resp.clan_name);
-        co_await this->characters.async_write([this, message, members](auto& characters) -> async::task<void> {
-            co_await characters.foreach (
-                [this, message](auto& ch) {
+        this->characters.write([this, message, members](auto& characters) {
+            characters.foreach_enqueue(
+                [this, message](auto& ch) -> async::task<void> {
                     ch->message(message, MESSAGE_TYPE::NOTIFY);
                     ch->clan_reset();
+                    co_return;
                 },
                 members);
         });
     });
     // If clan doesn't exist, callback is not called (no exception thrown)
+    co_return;
 }
 
 async::task<void> server::on_updated_clan(const internal_resp::UpdatedClan& resp)
@@ -454,9 +470,10 @@ async::task<void> server::on_updated_clan(const internal_resp::UpdatedClan& resp
                     members.push_back(shared_ptr);
                 }
 
-                co_await characters.foreach (
-                    [this, &resp](auto& member) {
+                characters.foreach_enqueue(
+                    [this, &resp](auto& member) -> async::task<void> {
                         member->message(std::format(_TEXT(MESSAGE_CLAN_MEMBER_JOINED), resp.new_member.value().name), MESSAGE_TYPE::NOTIFY);
+                        co_return;
                     },
                     members);
 
@@ -485,7 +502,7 @@ async::task<void> server::on_updated_clan(const internal_resp::UpdatedClan& resp
             if (resp.deleted_member.has_value() == false)
                 break;
 
-            co_await this->characters.async_write([this, &resp, clan](auto& characters) -> async::task<void> {
+            this->characters.write([this, &resp, clan](auto& characters) {
                 auto ch = characters.find(resp.deleted_member.value().name);
                 if (ch != nullptr)
                 {
@@ -516,9 +533,10 @@ async::task<void> server::on_updated_clan(const internal_resp::UpdatedClan& resp
 
                 auto message = resp.action == internal::ClanActionType::Kick ? std::format(_TEXT(MESSAGE_CLAN_MEMBER_KICKED), resp.deleted_member.value().name)
                                                                              : std::format(_TEXT(MESSAGE_CLAN_MEMBER_LEFT), resp.deleted_member.value().name);
-                co_await characters.foreach (
-                    [this, message](auto& member) {
+                characters.foreach_enqueue(
+                    [this, message](auto& member) -> async::task<void> {
                         member->message(message, MESSAGE_TYPE::NOTIFY);
+                        co_return;
                     },
                     members);
             });
@@ -581,12 +599,14 @@ async::task<void> server::on_clan_broadcast(const internal_resp::BroadcastClan& 
             members.push_back(shared_ptr);
         }
 
-        co_await this->characters.async_write([this, &resp, &members](auto& characters) -> async::task<void> {
-            co_await characters.foreach (
-                [this, resp](auto& member) {
+        this->characters.write([this, &resp, &members](auto& characters) {
+            characters.foreach_enqueue(
+                [this, resp](auto& member) -> async::task<void> {
                     member->message(resp.message, static_cast<MESSAGE_TYPE>(resp.type));
+                    co_return;
                 },
                 members);
         });
+        co_return;
     });
 }

--- a/server/game/lib/server/server.cpp
+++ b/server/game/lib/server/server.cpp
@@ -650,9 +650,10 @@ async::task<void> server::broadcast(const std::string& message, MESSAGE_TYPE typ
 
     case BROADCAST_TYPE::WORLD:
     {
-        co_await this->characters.async_write([message, type](auto& characters) -> async::task<void> {
-            co_await characters.foreach ([message, type](auto& ch) {
+        this->characters.write([message, type](auto& characters) {
+            characters.foreach_enqueue([message, type](auto& ch) -> async::task<void> {
                 ch->message(message, type);
+                co_return;
             });
         });
     }

--- a/server/game/lib/server/server.cpp
+++ b/server/game/lib/server/server.cpp
@@ -651,9 +651,8 @@ async::task<void> server::broadcast(const std::string& message, MESSAGE_TYPE typ
     case BROADCAST_TYPE::WORLD:
     {
         co_await this->characters.async_write([message, type](auto& characters) -> async::task<void> {
-            co_await characters.foreach ([message, type](auto& ch) -> async::task<void> {
+            co_await characters.foreach ([message, type](auto& ch) {
                 ch->message(message, type);
-                co_return;
             });
         });
     }

--- a/server/game/lib/server/server.group.cpp
+++ b/server/game/lib/server/server.group.cpp
@@ -383,18 +383,10 @@ async::task<void> server::on_updated_group(const internal_resp::UpdatedGroup& re
             if (resp.new_member.has_value() == false)
                 break;
 
-            group->add_member(resp.new_member.value().name);
-
-            co_await this->characters.async_write([this, &resp, group](auto& characters) -> async::task<void> {
-                auto ch = characters.find(resp.new_member.value().name);
+            auto new_member = std::string{resp.new_member.value().name};
+            co_await this->characters.async_write([this, new_member, group](auto& characters) -> async::task<void> {
+                auto ch = characters.find(new_member);
                 if (ch == nullptr)
-                    co_return;
-
-                auto weak          = ch->template weak_from_this_as<character>();
-                auto before_thread = this->threads.current();
-                auto after_thread  = ch->thread();
-                co_await after_thread->switching();
-                if (weak.expired())
                     co_return;
 
                 auto members = std::vector<std::shared_ptr<fb::game::character>>();
@@ -404,8 +396,8 @@ async::task<void> server::on_updated_group(const internal_resp::UpdatedGroup& re
                 }
 
                 characters.foreach_enqueue(
-                    [this, &resp](auto& member) -> async::task<void> {
-                        member->message(std::format(_TEXT(MESSAGE_GROUP_JOINED), resp.new_member.value().name), MESSAGE_TYPE::STATE);
+                    [this, new_member](auto& member) -> async::task<void> {
+                        member->message(std::format(_TEXT(MESSAGE_GROUP_JOINED), new_member), MESSAGE_TYPE::STATE);
                         co_return;
                     },
                     members);
@@ -413,17 +405,21 @@ async::task<void> server::on_updated_group(const internal_resp::UpdatedGroup& re
                 // Log group enter event (always log regardless of weak state)
                 auto log_data              = Json::Value();
                 log_data["character_id"]   = static_cast<Json::Int64>(ch->id);
-                log_data["character_name"] = UTF8(resp.new_member.value().name, PLATFORM::WINDOWS);
+                log_data["character_name"] = UTF8(new_member, PLATFORM::WINDOWS);
                 log_data["group_id"]       = static_cast<Json::Int64>(group->id());
                 this->log.write("group_enter", log_data);
 
-                if (weak.expired() == false)
-                {
-                    group->enter(weak);
-                    ch->group_id(group->id());
-                    ch->message(_TEXT(MESSAGE_GROUP_JOINED_SUCCESS), MESSAGE_TYPE::STATE);
-                }
-                co_await before_thread->switching();
+                auto weak = ch->template weak_from_this_as<character>();
+                group->enter(weak);
+                group->add_member(new_member);
+
+                auto thread = this->threads.current();
+                co_await ch->thread()->switching();
+                ch->group_id(group->id());
+                ch->message(_TEXT(MESSAGE_GROUP_JOINED_SUCCESS), MESSAGE_TYPE::STATE);
+
+                if (thread != nullptr)
+                    co_await thread->switching();
             });
             break;
         }

--- a/server/game/lib/server/server.group.cpp
+++ b/server/game/lib/server/server.group.cpp
@@ -43,35 +43,49 @@ void server::assert_group(uint32_t error, const std::string& actor) const
 async::task<void> server::ensure_group(uint32_t id, std::function<async::task<void>(std::shared_ptr<fb::game::group>&)> fn)
 {
     auto thread = this->threads.current();
-    co_await this->groups.async_write(
-        id,
-        [this, fn, thread](auto& group) -> async::task<void> {
-            if (thread != nullptr)
-                co_await thread->switching();
+    if (thread == nullptr)
+    {
+        throw std::runtime_error(std::format("No thread available for ensure_group (group_id: {})", id));
+    }
 
-            co_await fn(group);
+    // Use try_async_write with retry mechanism
+    // Note: We need to ensure we return to the original thread after try_async_write completes
+    auto success = co_await thread->enqueue_with_retry(
+        [=, this](auto& thread) -> async::task<bool> {
+            auto result = co_await this->groups.try_async_write(
+                id,
+                [this, fn, &thread](auto& group) -> async::task<void> {
+                    co_await fn(group);
+                    // Ensure we return to the original thread after fn completes
+                    co_await thread.switching();
+                },
+                [=, this]() -> async::task<std::shared_ptr<fb::game::group>> {
+                    auto&& resp = co_await this->http.get<internal_resp::GroupDetails>("internal", std::format("/group/{}", id));
+                    switch (static_cast<ERROR_CODE>(resp.error))
+                    {
+                    case ERROR_CODE::NONE:
+                    {
+                        auto members = std::vector<std::string>{};
+                        for (auto& member : resp.members)
+                        {
+                            members.push_back(member.name);
+                        }
+                        co_return this->make<fb::game::group>(id, resp.group.master, members);
+                    }
+
+                    default:
+                        throw std::runtime_error(std::format("cannot get group (error : {})", resp.error));
+                    }
+                });
+            co_return result;
         },
-        [=, this]() -> async::task<std::shared_ptr<fb::game::group>> {
-            auto&& resp = co_await this->http.get<internal_resp::GroupDetails>("internal", std::format("/group/{}", id));
-            switch (static_cast<ERROR_CODE>(resp.error))
-            {
-            case ERROR_CODE::NONE:
-            {
-                auto members = std::vector<std::string>{};
-                for (auto& member : resp.members)
-                {
-                    members.push_back(member.name);
-                }
-                co_return this->make<fb::game::group>(id, resp.group.master, members);
-            }
+        10 // max_retries
+    );
 
-            default:
-                throw std::runtime_error(std::format("cannot get group (error : {})", resp.error));
-            }
-        });
-
-    if (thread != nullptr)
-        co_await thread->switching();
+    if (!success)
+    {
+        throw std::runtime_error(std::format("Failed to acquire group lock after retries (group_id: {})", id));
+    }
 }
 
 async::task<void> server::create_group(character& me, const std::string& target_name)
@@ -389,9 +403,10 @@ async::task<void> server::on_updated_group(const internal_resp::UpdatedGroup& re
                     members.push_back(member_ptr);
                 }
 
-                co_await characters.foreach (
-                    [this, &resp](auto& member) {
+                characters.foreach_enqueue(
+                    [this, &resp](auto& member) -> async::task<void> {
                         member->message(std::format(_TEXT(MESSAGE_GROUP_JOINED), resp.new_member.value().name), MESSAGE_TYPE::STATE);
+                        co_return;
                     },
                     members);
 
@@ -454,9 +469,10 @@ async::task<void> server::on_updated_group(const internal_resp::UpdatedGroup& re
 
                 auto message = resp.action == internal::GroupActionType::Kick ? std::format(_TEXT(MESSAGE_GROUP_MEMBER_KICKED), resp.deleted_member.value().name)
                                                                               : std::format(_TEXT(MESSAGE_GROUP_MEMBER_LEFT), resp.deleted_member.value().name);
-                co_await characters.foreach (
-                    [this, message](auto& member) {
+                characters.foreach_enqueue(
+                    [this, message](auto& member) -> async::task<void> {
                         member->message(message, MESSAGE_TYPE::STATE);
+                        co_return;
                     },
                     members);
             });
@@ -474,16 +490,18 @@ async::task<void> server::on_destroyed_group(const internal_resp::DestroyGroup& 
     this->assert_group(resp.error, resp.actor.name);
 
     auto gid = resp.group_id;
-    co_await this->groups.async_erase(gid, [this, gid, &resp](const auto& group) -> async::task<void> {
+    this->groups.erase(gid, [this, gid, &resp](const auto& group) {
         auto members = std::vector<std::string>{group->members()};
 
-        co_await this->characters.async_write([this, &resp, &members](auto& characters) -> async::task<void> {
-            co_await characters.foreach (members, [](auto& ch) {
+        this->characters.write([this, &resp, &members](auto& characters) {
+            characters.foreach_enqueue(members, [](auto& ch) -> async::task<void> {
                 ch->group_reset();
                 ch->message(_TEXT(MESSAGE_GROUP_DISBANDED), MESSAGE_TYPE::STATE);
+                co_return;
             });
         });
     });
+    co_return;
 }
 
 async::task<void> server::on_group_broadcast(const internal_resp::BroadcastGroup& resp)
@@ -497,12 +515,14 @@ async::task<void> server::on_group_broadcast(const internal_resp::BroadcastGroup
             members.push_back(member_ptr);
         }
 
-        co_await this->characters.async_write([this, &message, &type, &members](auto& characters) -> async::task<void> {
-            co_await characters.foreach (
-                [this, message, type](auto& member) {
+        this->characters.write([this, &message, &type, &members](auto& characters) {
+            characters.foreach_enqueue(
+                [this, message, type](auto& member) -> async::task<void> {
                     member->message(message, static_cast<MESSAGE_TYPE>(type));
+                    co_return;
                 },
                 members);
         });
+        co_return;
     });
 }

--- a/server/game/lib/server/server.whisper.cpp
+++ b/server/game/lib/server/server.whisper.cpp
@@ -27,22 +27,23 @@ async::task<void> server::whisper(character& sender, std::string receiver_name, 
     if (sender.option(OPTION::WHISPER) == false)
         throw std::runtime_error(_TEXT(MESSAGE_WHISPER_DISABLED_MINE));
 
-    co_await this->characters.async_write([this, &sender, &receiver_name, &message](auto& characters) -> async::task<void> {
-        auto sender_weak = sender.weak_from_this_as<character>();
-        auto sender_name = sender.name();
-        auto receiver    = characters.find(receiver_name);
+    auto sender_weak = sender.weak_from_this_as<character>();
+    auto sender_name = sender.name();
+
+    // Try to find target in the same thread's thread_params
+    auto current_thread = this->threads.current();
+    if (current_thread != nullptr)
+    {
+        auto params   = current_thread->template data<thread_params>();
+        auto receiver = params->characters.find(receiver_name);
         if (receiver != nullptr)
         {
-            auto target_weak = receiver->template weak_from_this_as<character>();
-            co_await this->threads.switching(target_weak);
-            auto target_name = receiver->name();
-
+            // Found target in same thread - process without thread switching
             if (receiver->option(OPTION::WHISPER) == false)
                 throw std::runtime_error(std::format(_TEXT(MESSAGE_WHISPER_DISABLED_TARGET), receiver_name));
 
+            auto target_name = receiver->name();
             receiver->message(std::format("{}> {}", sender_name, message), MESSAGE_TYPE::NOTIFY);
-
-            co_await this->threads.switching(sender_weak);
             sender.message(std::format("{}< {}", target_name, message), MESSAGE_TYPE::NOTIFY);
 
             // Log whisper event
@@ -53,24 +54,24 @@ async::task<void> server::whisper(character& sender, std::string receiver_name, 
             log_data["receiver_name"] = UTF8(target_name, PLATFORM::WINDOWS);
             log_data["message"]       = UTF8(message, PLATFORM::WINDOWS);
             this->log.write("whisper", log_data);
+            co_return;
         }
-        else
-        {
-            auto&& resp = co_await this->http.post("internal", "/in-game/whisper", Whisper{sender_name, receiver_name, message});
-            co_await this->threads.switching(sender_weak);
+    }
 
-            co_await this->on_whisper(resp);
-            sender.message(std::format("{}< {}", receiver_name, message), MESSAGE_TYPE::NOTIFY);
+    // Target not found in same thread - call API for cross-server whisper
+    auto&& resp = co_await this->http.post("internal", "/in-game/whisper", Whisper{sender_name, receiver_name, message});
+    co_await this->threads.switching(sender_weak);
 
-            // Log whisper event (cross-server)
-            auto log_data             = Json::Value();
-            log_data["sender_id"]     = static_cast<Json::Int64>(sender.id);
-            log_data["sender_name"]   = UTF8(sender_name, PLATFORM::WINDOWS);
-            log_data["receiver_name"] = UTF8(receiver_name, PLATFORM::WINDOWS);
-            log_data["message"]       = UTF8(message, PLATFORM::WINDOWS);
-            this->log.write("whisper", log_data);
-        }
-    });
+    co_await this->on_whisper(resp);
+    sender.message(std::format("{}< {}", receiver_name, message), MESSAGE_TYPE::NOTIFY);
+
+    // Log whisper event (cross-server)
+    auto log_data             = Json::Value();
+    log_data["sender_id"]     = static_cast<Json::Int64>(sender.id);
+    log_data["sender_name"]   = UTF8(sender_name, PLATFORM::WINDOWS);
+    log_data["receiver_name"] = UTF8(receiver_name, PLATFORM::WINDOWS);
+    log_data["message"]       = UTF8(message, PLATFORM::WINDOWS);
+    this->log.write("whisper", log_data);
 }
 
 async::task<void> server::on_whisper(const internal_resp::Whisper& resp)

--- a/server/internal/Formatter/FlatBufferFormatter.cs
+++ b/server/internal/Formatter/FlatBufferFormatter.cs
@@ -25,6 +25,8 @@ namespace Internal.Formatter
             var protocolType = (Request.FlatBufferProtocolType)protocol.ProtocolType;
             switch (protocolType)
             {
+                case Request.FlatBufferProtocolType.Heartbeat:
+                    return null;
                 default:
                     return $"Request {protocolType} < {JsonConvert.SerializeObject(protocol)}";
             }
@@ -41,6 +43,8 @@ namespace Internal.Formatter
             var protocolType = (Response.FlatBufferProtocolType)protocol.ProtocolType;
             switch (protocolType)
             {
+                case Response.FlatBufferProtocolType.Heartbeat:
+                    return null;
                 default:
                     return $"Response {protocolType} > {JsonConvert.SerializeObject(protocol)}";
             }


### PR DESCRIPTION
This PR includes improvements to thread management, async locking, and message routing optimizations.

## Changes

- Add async lock retry mechanism and enqueue functions
  - Add try_lock and try_lock_shared to locker
  - Add try_async_read and try_async_write to locker and shard_container
  - Add enqueue_with_retry to thread for retry mechanism
  - Add foreach_enqueue functions to character container
  - Update clan and group operations to use try_async_write with retry
  - Replace foreach with foreach_enqueue in broadcast operations
  - Add callback support to shard_container erase method
  - Add to_string method to thread

- Refactor: route AMQP messages to least loaded logic thread
  - Rename _thread_container to _logic_threads in thread_container
  - Add queue_size() method to thread class
  - Add least_loaded() method to thread_container to find thread with smallest queue
  - Add thread_container reference to amqp::queue
  - Add invoke_async() method to queue that enqueues to least loaded thread
  - Update AMQP message processing to use invoke_async() instead of direct invoke
  - Change queue thread_container from pointer to reference

- Refactor: simplify broadcast foreach callback
  - Remove unnecessary async::task<void> return type from foreach callback
  - Remove redundant co_return statement

- Refactor: simplify group member join logic
  - Remove unnecessary thread switching in on_updated_group
  - Store new_member name in local variable for safer capture
  - Reorganize group->add_member and group->enter call order
  - Simplify weak pointer handling logic

- Fix: prevent use-after-free and optimize whisper handling
  - Store map information before on_transfer to avoid use-after-free in character map transfer
  - Optimize whisper to avoid unnecessary thread switching when target is in same thread
  - Exclude Heartbeat protocol from FlatBuffer formatter logging

- Style: fix indentation in rabbitmq.js
  - Fix indentation formatting in StatefulSet container configuration
  - Align volumeMounts, readinessProbe, and livenessProbe properly
  - Fix closing braces alignment

## Files Changed
- 21 files changed, 749 insertions(+), 267 deletions(-)