### PR TITLE
chore: limit parallel build jobs to 32 to prevent CPU overheating

### DIFF
--- a/server/bot/Dockerfile
+++ b/server/bot/Dockerfile
@@ -12,14 +12,7 @@ COPY server/bot ./bot
 
 WORKDIR /app/bot/build
 RUN cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
-RUN AVAILABLE_MEM_KB=$(grep MemAvailable /proc/meminfo | awk '{print $2}') && \
-    MEM_PER_JOB_KB=$((1500 * 1024)) && \
-    MAX_BY_MEM=$((AVAILABLE_MEM_KB / MEM_PER_JOB_KB)) && \
-    CPU_CORES=$(nproc) && \
-    if [ "$MAX_BY_MEM" -lt "$CPU_CORES" ]; then JOBS="$MAX_BY_MEM"; else JOBS="$CPU_CORES"; fi && \
-    if [ "$JOBS" -lt 1 ]; then JOBS=1; fi && \
-    echo "Building with ${JOBS} jobs (using Available Memory: ${AVAILABLE_MEM_KB} KB)" && \
-    cmake --build . --config ${BUILD_TYPE} --parallel "$JOBS"
+RUN cmake --build . --config ${BUILD_TYPE} --parallel 32
 
 FROM --platform=$BUILDPLATFORM ghcr.io/boyism80/fb/build
 WORKDIR /app

--- a/server/fb/Dockerfile
+++ b/server/fb/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /app/jsoncpp
 RUN git checkout 1.9.6
 WORKDIR /app/jsoncpp/build
 RUN cmake -DCMAKE_BUILD_TYPE=Release .. 
-RUN cmake --build . --parallel
+RUN cmake --build . --parallel 32
 RUN make install
 
 WORKDIR /app
@@ -37,14 +37,14 @@ WORKDIR /app/rabbitmq-c
 RUN git checkout v0.14.0
 WORKDIR /app/rabbitmq-c/build
 RUN cmake .. -DENABLE_SSL_SUPPORT=OFF
-RUN cmake --build . --config Release --parallel
+RUN cmake --build . --config Release --parallel 32
 RUN make install
 
 WORKDIR /app
 RUN git clone --recursive https://github.com/boyism80/lua
 WORKDIR /app/lua/build
 RUN cmake -DCMAKE_BUILD_TYPE=Release .. 
-RUN cmake --build . --parallel
+RUN cmake --build . --parallel 32
 RUN make install
 
 WORKDIR /app
@@ -53,14 +53,14 @@ WORKDIR /app/zlib
 RUN git checkout v1.2.9
 WORKDIR /app/zlib/build
 RUN cmake -DCMAKE_BUILD_TYPE=Release .. 
-RUN cmake --build . --parallel
+RUN cmake --build . --parallel 32
 RUN make install
 
 WORKDIR /app
 RUN git clone https://github.com/boyism80/flatbuffers
 WORKDIR /app/flatbuffers/build
 RUN cmake .. -DFLATBUFFERS_BUILD_FLATC=OFF -DFLATBUFFERS_BUILD_TESTS=OFF
-RUN cmake --build . --config Release --parallel
+RUN cmake --build . --config Release --parallel 32
 RUN make install
 
 WORKDIR /app
@@ -84,7 +84,7 @@ WORKDIR /app/hiredis
 RUN git checkout v1.2.0
 WORKDIR /app/hiredis/build
 RUN cmake -DCMAKE_BUILD_TYPE=Release .. 
-RUN cmake --build . --parallel
+RUN cmake --build . --parallel 32
 RUN make install
 
 # fb.lib
@@ -93,7 +93,7 @@ COPY include ./include
 COPY server/fb ./fb
 WORKDIR /app/fb/build
 RUN cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} .. 
-RUN cmake --build . --parallel
+RUN cmake --build . --parallel 32
 RUN make install
 
 RUN rm -rf /app

--- a/server/game/Dockerfile
+++ b/server/game/Dockerfile
@@ -13,14 +13,7 @@ RUN mkdir -p maps && unzip -qq maps.zip -d ./maps && rm -f maps.zip
 
 WORKDIR /app/game/build
 RUN cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
-RUN AVAILABLE_MEM_KB=$(grep MemAvailable /proc/meminfo | awk '{print $2}') && \
-    MEM_PER_JOB_KB=$((1500 * 1024)) && \
-    MAX_BY_MEM=$((AVAILABLE_MEM_KB / MEM_PER_JOB_KB)) && \
-    CPU_CORES=$(nproc) && \
-    if [ "$MAX_BY_MEM" -lt "$CPU_CORES" ]; then JOBS="$MAX_BY_MEM"; else JOBS="$CPU_CORES"; fi && \
-    if [ "$JOBS" -lt 1 ]; then JOBS=1; fi && \
-    echo "Building with ${JOBS} jobs (using Available Memory: ${AVAILABLE_MEM_KB} KB)" && \
-    cmake --build . --config ${BUILD_TYPE} --parallel "$JOBS"
+RUN cmake --build . --config ${BUILD_TYPE} --parallel 32
 
 FROM --platform=$BUILDPLATFORM ghcr.io/boyism80/fb/build
 

--- a/server/gateway/Dockerfile
+++ b/server/gateway/Dockerfile
@@ -9,7 +9,7 @@ COPY server/gateway ./gateway
 
 WORKDIR /app/gateway/build
 RUN cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
-RUN cmake --build . --config ${BUILD_TYPE} --parallel
+RUN cmake --build . --config ${BUILD_TYPE} --parallel 32
 
 FROM --platform=$BUILDPLATFORM ghcr.io/boyism80/fb/build
 WORKDIR /app

--- a/server/login/Dockerfile
+++ b/server/login/Dockerfile
@@ -9,7 +9,7 @@ COPY server/login ./login
 
 WORKDIR /app/login/build
 RUN cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
-RUN cmake --build . --config ${BUILD_TYPE} --parallel
+RUN cmake --build . --config ${BUILD_TYPE} --parallel 32
 
 FROM --platform=$BUILDPLATFORM ghcr.io/boyism80/fb/build
 WORKDIR /app


### PR DESCRIPTION
This PR limits parallel build jobs to 32 across all Dockerfiles to prevent CPU overheating during builds.

## Changes Summary

### Build Job Limiting
- Add --parallel 32 limit to all Dockerfile build commands
- Remove dynamic job calculation from game and bot Dockerfiles
- Unify build configuration across all server Dockerfiles (gateway, login, game, bot)
- Update fb Dockerfile with parallel limit for all dependencies (jsoncpp, rabbitmq-c, lua, zlib, flatbuffers, hiredis, fb)

### Motivation
The build PC (EPYC 7702 64-core) was experiencing thermal throttling with CPU cores reaching 95-97째C and frequency dropping to 500MHz. Limiting parallel jobs to 32 prevents excessive CPU load while maintaining reasonable build performance.

## Files Changed
- server/bot/Dockerfile
- server/fb/Dockerfile
- server/game/Dockerfile
- server/gateway/Dockerfile
- server/login/Dockerfile