### PR TITLE
feat: admin login world claim and users/bulletin improvements

### DIFF
--- a/server/admin-tool/Authentication/CustomAuthenticationStateProvider.cs
+++ b/server/admin-tool/Authentication/CustomAuthenticationStateProvider.cs
@@ -23,6 +23,12 @@ namespace AdminTool.Authentication
         }
 
         /// <summary>
+        /// Claim type for the world (server) the user logged in from.
+        /// Used to distinguish same user across worlds when changing roles.
+        /// </summary>
+        public const string LoginWorldClaimType = "LoginWorld";
+
+        /// <summary>
         /// Gets the current authentication state asynchronously.
         /// </summary>
         /// <returns>The current authentication state.</returns>
@@ -43,6 +49,10 @@ namespace AdminTool.Authentication
                     new Claim(ClaimTypes.NameIdentifier, authData.UserId.ToString()),
                     new Claim(ClaimTypes.Role, authData.Role.ToString())
                 };
+                if (authData.LoginWorld.HasValue)
+                {
+                    claims.Add(new Claim(LoginWorldClaimType, authData.LoginWorld.Value.ToString()));
+                }
 
                 var identity = new ClaimsIdentity(claims, "admin");
                 var user = new ClaimsPrincipal(identity);
@@ -109,6 +119,12 @@ namespace AdminTool.Authentication
         /// Gets or sets the user role.
         /// </summary>
         public string Role { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the world (server) the user logged in from.
+        /// Used to avoid treating a different-world user with the same character ID as "self".
+        /// </summary>
+        public uint? LoginWorld { get; set; }
     }
 }
 

--- a/server/admin-tool/Pages/Login.razor
+++ b/server/admin-tool/Pages/Login.razor
@@ -143,7 +143,8 @@
                     {
                         UserId = result.UserId.Value,
                         UserName = result.UserName,
-                        Role = result.Role.Value.ToString()
+                        Role = result.Role.Value.ToString(),
+                        LoginWorld = world
                     };
                     await customProvider.MarkUserAsAuthenticated(authData);
                 }

--- a/server/admin-tool/Pages/Users.razor
+++ b/server/admin-tool/Pages/Users.razor
@@ -348,20 +348,24 @@
     private RoleModel roleModel = new();
     private Role currentUserRole = Role.User;
     private uint currentUserId = 0;
+    private uint? loginWorld = null;
+    private uint? _lastLoadedWorld = null;
 
     protected override async Task OnInitializedAsync()
     {
         await LoadCurrentUserRole();
-        
-        // Check for search query from URL
-        var uri = Navigation.ToAbsoluteUri(Navigation.Uri);
-        var queryParams = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
-        if (queryParams.TryGetValue("search", out var searchValue) && !string.IsNullOrWhiteSpace(searchValue))
+        SyncFromUrl();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        SyncFromUrl();
+        if (selectedWorld.HasValue && selectedWorld.Value != _lastLoadedWorld)
         {
-            searchTerm = searchValue.ToString();
+            _lastLoadedWorld = selectedWorld.Value;
+            await LoadUsers();
+            UpdateUsersUrl();
         }
-        
-        await LoadUsers();
     }
 
     private async Task LoadCurrentUserRole()
@@ -371,6 +375,7 @@
         {
             var roleClaim = authState.User.FindFirst(System.Security.Claims.ClaimTypes.Role);
             var idClaim = authState.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier);
+            var loginWorldClaim = authState.User.FindFirst(CustomAuthenticationStateProvider.LoginWorldClaimType);
             if (idClaim != null && uint.TryParse(idClaim.Value, out var uid))
             {
                 currentUserId = uid;
@@ -379,7 +384,22 @@
             {
                 currentUserRole = role;
             }
+            if (loginWorldClaim != null && uint.TryParse(loginWorldClaim.Value, out var world))
+            {
+                loginWorld = world;
+            }
         }
+    }
+
+    /// <summary>
+    /// True when the user is the logged-in user on the same world (avoids cross-world ID collision).
+    /// </summary>
+    private bool IsSelfUser(UserListItem user)
+    {
+        return user.Id == currentUserId
+            && loginWorld.HasValue
+            && selectedWorld.HasValue
+            && selectedWorld.Value == loginWorld.Value;
     }
 
     private bool CanModifyUser(UserListItem user)
@@ -390,7 +410,7 @@
 
     private bool RequiresElevationForTarget(UserListItem user)
     {
-        if (user.Id == currentUserId)
+        if (IsSelfUser(user))
             return false;
 
         return !CanModifyUser(user);
@@ -429,7 +449,7 @@
 
     private string GetChangeRoleButtonTitle(UserListItem user)
     {
-        if (user.Id == currentUserId)
+        if (IsSelfUser(user))
             return "Modify your own role. The elevation secret is required only for promotions.";
 
         return RequiresElevationForTarget(user)
@@ -440,6 +460,39 @@
     private List<Role> GetAvailableRoles()
     {
         return Enum.GetValues<Role>().ToList();
+    }
+
+    private void SyncFromUrl()
+    {
+        try
+        {
+            var uri = Navigation.ToAbsoluteUri(Navigation.Uri);
+            if (uri.AbsolutePath != "/users")
+                return;
+            var queryParams = Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(uri.Query);
+            if (queryParams.TryGetValue("search", out var searchValue))
+                searchTerm = searchValue.ToString() ?? string.Empty;
+            if (queryParams.TryGetValue("page", out var pageValue) && int.TryParse(pageValue, out var page) && page >= 1)
+                currentPage = page;
+        }
+        catch { /* ignore URL parse errors */ }
+    }
+
+    private void UpdateUsersUrl()
+    {
+        try
+        {
+            var query = new Dictionary<string, string?>();
+            if (selectedWorld.HasValue)
+                query["world"] = selectedWorld.Value.ToString();
+            if (!string.IsNullOrWhiteSpace(searchTerm))
+                query["search"] = searchTerm;
+            if (currentPage > 1)
+                query["page"] = currentPage.ToString();
+            var url = Microsoft.AspNetCore.WebUtilities.QueryHelpers.AddQueryString("/users", query);
+            Navigation.NavigateTo(url);
+        }
+        catch { /* ignore */ }
     }
 
     private async Task LoadUsers()
@@ -470,6 +523,7 @@
     {
         currentPage = 1;
         await LoadUsers();
+        UpdateUsersUrl();
     }
 
     private async Task ClearSearch()
@@ -477,6 +531,7 @@
         searchTerm = string.Empty;
         currentPage = 1;
         await LoadUsers();
+        UpdateUsersUrl();
     }
 
     private async Task HandleKeyPress(KeyboardEventArgs e)
@@ -493,6 +548,7 @@
         {
             currentPage = page;
             await LoadUsers();
+            UpdateUsersUrl();
         }
     }
 
@@ -546,7 +602,7 @@
             return;
 
         var targetRole = (Role)selectedUser.Role;
-        var isSelf = selectedUser.Id == currentUserId;
+        var isSelf = IsSelfUser(selectedUser);
 
         if (!selectedWorld.HasValue)
         {
@@ -632,7 +688,8 @@
                     {
                         UserId = currentUserId,
                         UserName = character.Name,
-                        Role = newRole.ToString()
+                        Role = newRole.ToString(),
+                        LoginWorld = loginWorld
                     };
                     await customProvider.MarkUserAsAuthenticated(authData);
                 }

--- a/server/admin-tool/Services/UserService.cs
+++ b/server/admin-tool/Services/UserService.cs
@@ -94,33 +94,26 @@ namespace AdminTool.Services
                 };
             }
 
-            // Get user details from sharded user tables
+            // Get user details via Character repository (Redis cache) so list matches role changes.
             var userIds = nameList.Select(n => n.Id).ToList();
             var userDetailsDict = new Dictionary<uint, UserListItem>();
 
-            // Query each shard for user details
-            foreach (var (conn, idList) in _dbContext.GetShardConnections(world, userIds))
+            foreach (var userId in userIds)
             {
-                var userQuery = """
-                    SELECT 
-                        `id`,
-                        `name`,
-                        `role`,
-                        `level`,
-                        `money`,
-                        `created_date`,
-                        `updated_date`
-                    FROM `user`
-                    WHERE `id` IN @userIds AND `deleted` = 0
-                    """;
+                var character = await _dbContext.Character.Get(world, userId);
+                if (character == null || character.Deleted)
+                    continue;
 
-                var shardUsers = await conn.QueryAsync<UserListItem>(userQuery, new { userIds = idList });
-                foreach (var user in shardUsers)
+                userDetailsDict[userId] = new UserListItem
                 {
-                    userDetailsDict[user.Id] = user;
-                }
-
-                await conn.DisposeAsync();
+                    Id = character.Id,
+                    Name = character.Name,
+                    Role = (byte)character.Role,
+                    Level = (ushort)character.Level,
+                    Money = character.Money,
+                    CreatedDate = character.CreatedDate,
+                    UpdatedDate = character.UpdatedDate
+                };
             }
 
             // Combine name/ban info with user details

--- a/server/admin-tool/Shared/MainLayout.razor
+++ b/server/admin-tool/Shared/MainLayout.razor
@@ -217,7 +217,11 @@
     {
         if (e.Key == "Enter" && !string.IsNullOrWhiteSpace(globalSearchTerm))
         {
-            Navigation.NavigateTo($"/users?search={Uri.EscapeDataString(globalSearchTerm)}");
+            var query = new Dictionary<string, string?> { ["search"] = globalSearchTerm.Trim() };
+            if (selectedWorld.HasValue)
+                query["world"] = selectedWorld.Value.ToString();
+            var queryString = QueryHelpers.AddQueryString("/users", query);
+            Navigation.NavigateTo(queryString);
         }
         return Task.CompletedTask;
     }

--- a/server/http/Service/BulletinService.cs
+++ b/server/http/Service/BulletinService.cs
@@ -37,7 +37,7 @@ namespace Http.Service
             return request.CompletionSource.Task;
         }
 
-        public async Task<int> Delete(uint world, uint bulletinSection, uint id, uint user, bool ignoreOwner = false)
+        public async Task<int> Delete(uint world, uint section, uint id, uint user, bool ignoreOwner = false)
         {
             using var scope = _scopeFactory.CreateScope();
             var dbContext = scope.ServiceProvider.GetRequiredService<DbContext>();
@@ -60,13 +60,13 @@ namespace Http.Service
                 // Delete from Redis cache if successful
                 if (result == 1)
                 {
-                    await _cacheService.DeleteArticlesBatchAsync(world, new List<(uint bulletinSection, uint id)> { (bulletinSection, id) });
+                    await _cacheService.DeleteArticlesBatchAsync(world, new List<(uint section, uint id)> { (section, id) });
 
                     // Log bulletin delete event
                     _logService?.Write("bulletin_delete", new
                     {
                         world = world,
-                        bulletinSection = bulletinSection,
+                        section = section,
                         article_id = id,
                         user_id = user,
                         ignore_owner = ignoreOwner
@@ -82,7 +82,7 @@ namespace Http.Service
             }
         }
 
-        public async Task<int> DeleteBatch(uint world, uint bulletinSection, List<uint> ids, uint user, bool ignoreOwner = false)
+        public async Task<int> DeleteBatch(uint world, uint section, List<uint> ids, uint user, bool ignoreOwner = false)
         {
             using var scope = _scopeFactory.CreateScope();
             var dbContext = scope.ServiceProvider.GetRequiredService<DbContext>();
@@ -92,7 +92,7 @@ namespace Http.Service
                 await using var conn = dbContext.GetGlobalConnection(world);
                 await conn.OpenAsync();
 
-                var deletedIds = new List<(uint bulletinSection, uint id)>();
+                var deletedIds = new List<(uint section, uint id)>();
                 var successCount = 0;
 
                 foreach (var id in ids)
@@ -109,7 +109,7 @@ namespace Http.Service
 
                     if (result == 1)
                     {
-                        deletedIds.Add((bulletinSection, id));
+                        deletedIds.Add((section, id));
                         successCount++;
                     }
                 }
@@ -123,7 +123,7 @@ namespace Http.Service
                     _logService?.Write("bulletin_delete_batch", new
                     {
                         world = world,
-                        bulletinSection = bulletinSection,
+                        section = section,
                         article_ids = deletedIds.Select(x => x.id).ToList(),
                         user_id = user,
                         ignore_owner = ignoreOwner,
@@ -139,7 +139,7 @@ namespace Http.Service
             }
         }
 
-        public async Task<int> Update(uint world, uint bulletinSection, uint id, uint user, string title, string contents, bool ignoreOwner = false)
+        public async Task<int> Update(uint world, uint section, uint id, uint user, string title, string contents, bool ignoreOwner = false)
         {
             using var scope = _scopeFactory.CreateScope();
             var dbContext = scope.ServiceProvider.GetRequiredService<DbContext>();
@@ -163,21 +163,21 @@ namespace Http.Service
 
                 if (result == 1)
                 {
-                    var (article, _) = await LoadArticleFromDatabase(world, bulletinSection, id);
+                    var (article, _) = await LoadArticleFromDatabase(world, section, id);
                     if (article != null)
                     {
-                        await _cacheService.SetArticleAsync(world, bulletinSection, id, article);
+                        await _cacheService.SetArticleAsync(world, section, id, article);
                     }
                     else
                     {
-                        await _cacheService.DeleteArticlesBatchAsync(world, new List<(uint bulletinSection, uint id)> { (bulletinSection, id) });
+                        await _cacheService.DeleteArticlesBatchAsync(world, new List<(uint section, uint id)> { (section, id) });
                     }
 
                     // Log bulletin update event
                     _logService?.Write("bulletin_update", new
                     {
                         world = world,
-                        bulletinSection = bulletinSection,
+                        section = section,
                         article_id = id,
                         user_id = user,
                         ignore_owner = ignoreOwner
@@ -195,7 +195,7 @@ namespace Http.Service
         public Dictionary<uint, List<BulletinWriteRequest>> DequeueBatch(int maxBatchSize)
         {
             var writes = new Dictionary<uint, List<BulletinWriteRequest>>();
-            foreach (var (bulletinSection, queue) in _writeQueues)
+            foreach (var (section, queue) in _writeQueues)
             {
                 var batch = new List<BulletinWriteRequest>();
                 while (batch.Count < maxBatchSize && queue.TryDequeue(out var request))
@@ -203,13 +203,13 @@ namespace Http.Service
                     batch.Add(request);
                 }
                 if (batch.Count > 0)
-                    writes[bulletinSection] = batch;
+                    writes[section] = batch;
             }
 
             return writes;
         }
 
-        public async Task<List<Bulletin>> GetArticleListAsync(uint world, uint bulletinSection, ushort offset, string searchQuery = null)
+        public async Task<List<Bulletin>> GetArticleListAsync(uint world, uint section, ushort offset, string searchQuery = null)
         {
             using var scope = _scopeFactory.CreateScope();
             var dbContext = scope.ServiceProvider.GetRequiredService<DbContext>();
@@ -221,7 +221,7 @@ namespace Http.Service
             if (string.IsNullOrWhiteSpace(searchQuery))
             {
                 var dynamicParams = new DynamicParameters();
-                dynamicParams.Add("bulletinSection", bulletinSection);
+                dynamicParams.Add("section", section);
                 dynamicParams.Add("position", offset);
 
                 var articles = await conn.QueryAsync<Bulletin>(
@@ -247,15 +247,15 @@ namespace Http.Service
                 }
 
                 var sql = @"
-                    SELECT b.id, b.bulletinSection, b.user, b.title, b.contents, b.created_date, b.updated_date, b.deleted
+                    SELECT b.id, b.section, b.user, b.title, b.contents, b.created_date, b.updated_date, b.deleted
                     FROM bulletin b
-                    WHERE b.bulletinSection = @bulletinSection 
+                    WHERE b.section = @section 
                       AND b.deleted = 0
                       AND @position >= b.id
                       AND (b.title LIKE @search OR b.contents LIKE @search";
 
                 var dynamicParams = new DynamicParameters();
-                dynamicParams.Add("bulletinSection", bulletinSection);
+                dynamicParams.Add("section", section);
                 dynamicParams.Add("search", searchPattern);
                 dynamicParams.Add("position", offset);
 
@@ -287,17 +287,17 @@ namespace Http.Service
             return articleList;
         }
 
-        public async Task<(Bulletin Article, bool Next)> GetArticleAsync(uint world, uint bulletinSection, uint id)
+        public async Task<(Bulletin Article, bool Next)> GetArticleAsync(uint world, uint section, uint id)
         {
             bool? nextFlagFromLoader = null;
 
             var article = await _cacheService.GetArticleAsync(
                 world,
-                bulletinSection,
+                section,
                 id,
                 async () =>
                 {
-                    var (dbArticle, next) = await LoadArticleFromDatabase(world, bulletinSection, id);
+                    var (dbArticle, next) = await LoadArticleFromDatabase(world, section, id);
                     nextFlagFromLoader = next;
                     return dbArticle;
                 });
@@ -305,18 +305,18 @@ namespace Http.Service
             if (article == null)
                 return (null, false);
 
-            var nextFlag = nextFlagFromLoader ?? await LoadNextFlagAsync(world, bulletinSection, id);
+            var nextFlag = nextFlagFromLoader ?? await LoadNextFlagAsync(world, section, id);
             return (article, nextFlag);
         }
 
-        private async Task<(Bulletin Article, bool Next)> LoadArticleFromDatabase(uint world, uint bulletinSection, uint id)
+        private async Task<(Bulletin Article, bool Next)> LoadArticleFromDatabase(uint world, uint section, uint id)
         {
             using var scope = _scopeFactory.CreateScope();
             var dbContext = scope.ServiceProvider.GetRequiredService<DbContext>();
 
             await using var conn = dbContext.GetGlobalConnection(world);
             var dynamicParams = new DynamicParameters();
-            dynamicParams.Add("bulletinSection", bulletinSection);
+            dynamicParams.Add("section", section);
             dynamicParams.Add("article", id);
             await using var reader = await conn.QueryMultipleAsync(
                 "USP_BULLETIN_GET",
@@ -333,14 +333,14 @@ namespace Http.Service
             return (dbArticle, next);
         }
 
-        private async Task<bool> LoadNextFlagAsync(uint world, uint bulletinSection, uint id)
+        private async Task<bool> LoadNextFlagAsync(uint world, uint section, uint id)
         {
             using var scope = _scopeFactory.CreateScope();
             var dbContext = scope.ServiceProvider.GetRequiredService<DbContext>();
 
             await using var conn = dbContext.GetGlobalConnection(world);
             var dynamicParams = new DynamicParameters();
-            dynamicParams.Add("bulletinSection", bulletinSection);
+            dynamicParams.Add("section", section);
             dynamicParams.Add("article", id);
             await using var reader = await conn.QueryMultipleAsync(
                 "USP_BULLETIN_GET",


### PR DESCRIPTION
## Summary
Admin tool: add login world claim for same-world user detection, Users page URL sync and world-aware self check, UserService uses Character repository for user list. HTTP: BulletinService parameter rename (bulletinSection to section).

## Commits
- 7b84c048 feat: admin login world claim and users/bulletin improvements

## Changes
- **CustomAuthenticationStateProvider**: Add LoginWorld claim type and AuthData.LoginWorld for same-world user detection
- **Login.razor**: Pass world into auth data on login
- **Users.razor**: IsSelfUser by world; URL sync (search/page/world); reload on world change
- **UserService**: Use Character repository for user list instead of sharded user tables
- **MainLayout.razor**: Include world in global search navigation to users
- **BulletinService**: Rename bulletinSection parameter to section

Made with [Cursor](https://cursor.com)