### PR TITLE
fix: bulletin read/write/delete use same data shard

### DIFF
--- a/server/http/Service/BulletinService.Background.cs
+++ b/server/http/Service/BulletinService.Background.cs
@@ -74,7 +74,8 @@ namespace Http.Service
 
                 try
                 {
-                    await using var conn = dbContext.GetDataConnection(world, (int)bulletinSection);
+                    await using var conn = dbContext.GetShardConnection(world, bulletinSection);
+                    // Connection must be open before BeginTransactionAsync (Dapper does not open for transactions).
                     await conn.OpenAsync(cancellationToken);
 
                     // Start transaction for sequence management

--- a/server/http/Service/BulletinService.cs
+++ b/server/http/Service/BulletinService.cs
@@ -44,8 +44,7 @@ namespace Http.Service
 
             try
             {
-                await using var conn = dbContext.GetGlobalConnection(world);
-                await conn.OpenAsync();
+                await using var conn = dbContext.GetShardConnection(world, section);
 
                 var dynamicParams = new DynamicParameters();
                 dynamicParams.Add("id", id);
@@ -89,8 +88,7 @@ namespace Http.Service
 
             try
             {
-                await using var conn = dbContext.GetGlobalConnection(world);
-                await conn.OpenAsync();
+                await using var conn = dbContext.GetShardConnection(world, section);
 
                 var deletedIds = new List<(uint section, uint id)>();
                 var successCount = 0;
@@ -146,8 +144,7 @@ namespace Http.Service
 
             try
             {
-                await using var conn = dbContext.GetGlobalConnection(world);
-                await conn.OpenAsync();
+                await using var conn = dbContext.GetShardConnection(world, section);
 
                 var dynamicParams = new DynamicParameters();
                 dynamicParams.Add("p_id", id);
@@ -220,7 +217,7 @@ namespace Http.Service
             using var scope = _scopeFactory.CreateScope();
             var dbContext = scope.ServiceProvider.GetRequiredService<DbContext>();
 
-            await using var conn = dbContext.GetGlobalConnection(world);
+            await using var conn = dbContext.GetShardConnection(world, section);
 
             List<Bulletin> articleList;
 
@@ -320,7 +317,7 @@ namespace Http.Service
             using var scope = _scopeFactory.CreateScope();
             var dbContext = scope.ServiceProvider.GetRequiredService<DbContext>();
 
-            await using var conn = dbContext.GetGlobalConnection(world);
+            await using var conn = dbContext.GetShardConnection(world, section);
             var dynamicParams = new DynamicParameters();
             dynamicParams.Add("section", section);
             dynamicParams.Add("article", id);
@@ -344,7 +341,7 @@ namespace Http.Service
             using var scope = _scopeFactory.CreateScope();
             var dbContext = scope.ServiceProvider.GetRequiredService<DbContext>();
 
-            await using var conn = dbContext.GetGlobalConnection(world);
+            await using var conn = dbContext.GetShardConnection(world, section);
             var dynamicParams = new DynamicParameters();
             dynamicParams.Add("section", section);
             dynamicParams.Add("article", id);


### PR DESCRIPTION
## Summary
Bulletin list, get, delete, update and background write now use the same data shard so that section can be 0~N (any value, including greater than the number of DB shards).

## Changes
- Use \GetShardConnection(world, section)\ so section maps via \section % shardSize\ (replaces \GetGlobalConnection\ / \GetDataConnection(world, (int)section)\)
- Bulletin summary list, article get, delete, delete batch, and update use the same shard as write
- Remove redundant \OpenAsync()\ where Dapper opens the connection automatically; keep \OpenAsync()\ only before \BeginTransactionAsync()\ in BulletinBackgroundService

## Commits
- 8dfedd1a fix: bulletin read/write/delete use same data shard