### PR TITLE
Fix transfer delay and remove Lua pending state

### DIFF
--- a/include/fb/lua.h
+++ b/include/fb/lua.h
@@ -45,8 +45,6 @@ extern "C"
     }                     \
     }
 
-#define LUA_PENDING (LUA_ERRERR + 1)
-
 namespace fb {
 
 class thread;
@@ -246,7 +244,6 @@ public:
 
 private:
     context*     _parent = nullptr;
-    int          _state  = 0;
     promise_type _promise;
     bool         _auto_release = false;
 
@@ -533,10 +530,7 @@ public:
     [[nodiscard]] async::task<bool> call(int argc, bool auto_release = true, int* n = nullptr);
     void                            resume(int argc, int* n = nullptr);
     int                             yield(int retc);
-    int                             state() const;
     void                            release();
-    bool                            pending() const;
-    void                            pending(bool value);
     void                            parent(context* parent);
     context*                        parent() const;
     int                             ensure_yield(fb::async_executor&                  executor,

--- a/server/fb/src/lua.cpp
+++ b/server/fb/src/lua.cpp
@@ -363,9 +363,6 @@ async::task<bool> context::call(int argc, bool auto_release, int* n)
 
 void fb::lua::context::resume(int argc, int* n)
 {
-    if (this->_state == LUA_YIELD)
-        this->_state = LUA_OK;
-
     if (this->_promise == nullptr)
         return;
 
@@ -375,32 +372,23 @@ void fb::lua::context::resume(int argc, int* n)
         return;
     }
 
-    auto root = static_cast<fb::lua::root*>(this->owner);
-    if (this->_state == LUA_PENDING)
+    auto root  = static_cast<fb::lua::root*>(this->owner);
+    auto state = lua_resume(*this, nullptr, argc);
+    if (state == LUA_YIELD)
         return;
 
-    auto state = lua_resume(*this, nullptr, argc);
-
-    if (this->_state != LUA_PENDING)
-        this->_state = state;
-
-    switch (this->_state)
+    if (state != LUA_OK)
     {
-    case LUA_PENDING:
-    case LUA_YIELD:
-        break;
-
-    case LUA_ERRRUN:
-    case LUA_ERRERR:
-    {
+        // Any non-LUA_OK and non-LUA_YIELD means Lua errored.
         lua_pop(*this, 1);
         auto message = std::format("lua error message : {}", this->tostring(-1).c_str());
         fb::logger::fatal(message);
+
         auto promise = promise_type{this->_promise};
         auto parent  = this->_parent;
         root->revoke(*this);
 
-        if (parent != nullptr && parent->_state == LUA_YIELD)
+        if (parent != nullptr && lua_status(*parent) == LUA_YIELD)
         {
             async::awaitable_then(parent->_initial_thread.switching(), [=](auto result) {
                 parent->resume(0);
@@ -408,9 +396,7 @@ void fb::lua::context::resume(int argc, int* n)
         }
         promise->set_exception(std::make_exception_ptr(std::runtime_error(message)));
     }
-    break;
-
-    default:
+    else // LUA_OK: coroutine finished successfully.
     {
         auto parent = this->_parent;
         if (parent != nullptr)
@@ -421,7 +407,7 @@ void fb::lua::context::resume(int argc, int* n)
                     *n = argc;
 
                 lua_xmove(*this, *parent, argc);
-                if (parent->_state == LUA_YIELD)
+                if (lua_status(*parent) == LUA_YIELD)
                     parent->resume(argc);
             });
         }
@@ -430,8 +416,6 @@ void fb::lua::context::resume(int argc, int* n)
 
         this->_promise->set_value(true);
     }
-    break;
-    }
 }
 
 int context::yield(int retc)
@@ -439,15 +423,12 @@ int context::yield(int retc)
     return lua_yield(*this, retc);
 }
 
-int context::state() const
-{
-    return this->_state;
-}
-
 void context::release()
 {
     auto root = static_cast<fb::lua::root*>(this->owner);
-    switch (this->_state)
+
+    auto status = lua_status(*this);
+    switch (status)
     {
     case LUA_OK:
         root->release(*this);
@@ -457,16 +438,6 @@ void context::release()
         root->revoke(*this);
         break;
     }
-}
-
-bool context::pending() const
-{
-    return this->_state == LUA_PENDING;
-}
-
-void context::pending(bool value)
-{
-    this->_state = value ? LUA_PENDING : LUA_YIELD;
 }
 
 int context::ensure_yield(fb::async_executor&                  executor,
@@ -656,7 +627,7 @@ void root::release(context& ctx)
         if (this->idle.contains(ctx))
             return;
 
-        if (ctx.state() != LUA_OK)
+        if (lua_status(ctx) != LUA_OK)
             throw std::runtime_error("lua ctx's current state is not LUA_OK");
 
         lua_settop(ctx, 0);

--- a/server/game/lib/builtin/object.cpp
+++ b/server/game/lib/builtin/object.cpp
@@ -940,9 +940,8 @@ int builtin::object::builtin_script(lua_State* L)
 
         auto n      = 0;
         std::ignore = new_lua->call(argc - 2, true, &n);
-        switch (new_lua->state())
+        switch (lua_status(*new_lua))
         {
-        case LUA_PENDING:
         case LUA_YIELD:
             return lua->yield(0);
 

--- a/server/game/lib/builtin/server.cpp
+++ b/server/game/lib/builtin/server.cpp
@@ -48,11 +48,9 @@ int builtin::server::builtin_sleep(lua_State* L)
         return 0;
 
     auto ms = (uint32_t)lua->tointeger(1);
-    lua->pending(true);
 
     auto server = lua->env<fb::game::server>("server");
     async::awaitable_then(server->sleep(std::chrono::milliseconds(ms)), [lua](auto result) {
-        lua->pending(false);
         lua->resume(0);
     });
     return lua->yield(0);

--- a/server/game/lib/listener/listener.character.cpp
+++ b/server/game/lib/listener/listener.character.cpp
@@ -144,20 +144,32 @@ async::task<bool> listener_impl::on_transfer(character& me, map& map, const fb::
             throw std::runtime_error(std::format(_TEXT(MESSAGE_UNKNOWN_ERROR_WITH_CODE), resp.error));
         }
 
-        std::ignore = co_await me.map(nullptr);
-        std::ignore = this->server.save(me);
-        auto stream = fb::stream();
-        auto writer = fb::stream_writer<big_endian>(stream);
-        writer.write<uint32_t>(me.id);
-        writer.write<std::string>(me.name());
-        writer.write<uint8_t>(1);
-        writer.write<uint16_t>(map.model.id);
-        writer.write<uint16_t>(p.x);
-        writer.write<uint16_t>(p.y);
+        auto commit_now = [this, ip = resp.ip, port = resp.port, map_id = map.model.id, pos_x = p.x, pos_y = p.y](
+                              character& ch) -> async::task<void> {
+            std::ignore = co_await ch.map(nullptr);
+            std::ignore = this->server.save(ch);
 
-        auto socket_ptr = me.socket_ptr();
-        if (socket_ptr != nullptr)
-            std::ignore = this->server.transfer(*socket_ptr, resp.ip, resp.port, internal::Service::Game, stream);
+            auto stream = fb::stream();
+            auto writer = fb::stream_writer<big_endian>(stream);
+            writer.write<uint32_t>(ch.id);
+            writer.write<std::string>(ch.name());
+            writer.write<uint8_t>(1);
+            writer.write<uint16_t>(map_id);
+            writer.write<uint16_t>(pos_x);
+            writer.write<uint16_t>(pos_y);
+
+            auto socket_ptr = ch.socket_ptr();
+            if (socket_ptr != nullptr)
+                std::ignore = this->server.transfer(*socket_ptr, ip, port, internal::Service::Game, stream);
+        };
+
+        this->server.threads.enqueue(weak, [this, commit_now, weak](auto&) -> async::task<void> {
+            auto shared = weak.lock();
+            if (shared == nullptr)
+                co_return;
+
+            co_await commit_now(*shared);
+        });
         co_return true;
     }
     catch (std::exception& e)


### PR DESCRIPTION
This PR includes the following commits since release/latest:
- a40447dc: fix: delay cross-server transfer commit
- ae3cff5c: refactor: remove Lua pending state

Touched files: include/fb/lua.h, server/fb/src/lua.cpp, server/game/lib/builtin/object.cpp, server/game/lib/builtin/server.cpp, server/game/lib/listener/listener.character.cpp