### PR TITLE
feat: add execution context propagation and develop sync

### DIFF
--- a/include/fb/acceptor.h
+++ b/include/fb/acceptor.h
@@ -2,6 +2,8 @@
 #define __FB_ACCEPTOR_H__
 
 #include <ctime>
+#include <fb/context.h>
+#include <fb/execution_context.h>
 #include <fb/mutex.h>
 #include <fb/protocol/flatbuffer/protocol.h>
 #include <fb/protocol/transfer.h>
@@ -132,7 +134,10 @@ private:
                     auto fd       = socket.fd();
                     auto weak     = socket.template weak_from_this_as<fb::socket<T>>();
                     auto builder  = this->threads.new_builder(weak);
-                    builder.func  = [this, protocol, weak, fd, opcode](auto& thread) -> async::task<void> {
+                    auto frame    = execution_context::create();
+                    frame->slot(context::local::slot_id(), context{.transaction_id = mint_transaction_id()});
+                    builder.context = execution_context::token(std::move(frame));
+                    builder.func    = [this, protocol, weak, fd, opcode](auto& thread) -> async::task<void> {
                         try
                         {
                             if (weak.expired())

--- a/include/fb/async_local.h
+++ b/include/fb/async_local.h
@@ -1,0 +1,42 @@
+#ifndef __ASYNC_LOCAL_H__
+#define __ASYNC_LOCAL_H__
+
+#include <fb/execution_context.h>
+#include <atomic>
+#include <utility>
+
+namespace fb {
+
+namespace detail {
+
+inline std::size_t allocate_async_local_slot()
+{
+    static std::atomic<std::size_t> next{1};
+    return next.fetch_add(1, std::memory_order_relaxed);
+}
+
+} // namespace detail
+
+template <typename T>
+class async_local
+{
+public:
+    [[nodiscard]] static std::size_t slot_id()
+    {
+        static std::size_t id = detail::allocate_async_local_slot();
+        return id;
+    }
+
+    [[nodiscard]] static T* try_get()
+    {
+        auto ambient = execution_context::current();
+        if (ambient == nullptr)
+            return nullptr;
+
+        return ambient->slot<T>(slot_id());
+    }
+};
+
+} // namespace fb
+
+#endif // !__ASYNC_LOCAL_H__

--- a/include/fb/context.h
+++ b/include/fb/context.h
@@ -1,0 +1,28 @@
+#ifndef __CONTEXT_H__
+#define __CONTEXT_H__
+
+#include <fb/async_local.h>
+
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <string>
+
+namespace fb {
+
+struct context
+{
+    std::string transaction_id;
+
+    using local = async_local<context>;
+};
+
+inline std::string mint_transaction_id()
+{
+    static auto gen = boost::uuids::random_generator{};
+    return boost::uuids::to_string(gen());
+}
+
+} // namespace fb
+
+#endif // !__CONTEXT_H__

--- a/include/fb/execution_context.h
+++ b/include/fb/execution_context.h
@@ -1,0 +1,63 @@
+#ifndef __EXECUTION_CONTEXT_H__
+#define __EXECUTION_CONTEXT_H__
+
+#include <async/propagation.h>
+#include <cstddef>
+#include <memory>
+#include <unordered_map>
+
+namespace fb {
+
+class async_executor;
+
+class execution_context
+{
+public:
+    using slot_key     = std::size_t;
+    using slot_storage = std::unordered_map<slot_key, std::shared_ptr<void>>;
+
+    static std::shared_ptr<execution_context> create();
+
+    [[nodiscard]] static std::shared_ptr<execution_context> current();
+    [[nodiscard]] static std::shared_ptr<execution_context> active();
+    static void                                             active(std::shared_ptr<execution_context> value);
+
+    [[nodiscard]] static async::propagation::token token();
+    [[nodiscard]] static async::propagation::token token(async::propagation::token value);
+    [[nodiscard]] static async::propagation::token token(std::shared_ptr<execution_context> value);
+
+    [[nodiscard]] static std::shared_ptr<execution_context> frame(async::propagation::token value);
+
+    static void pending(async::propagation::token value);
+
+    static void install_propagation_hooks(async_executor& executor);
+
+    template <typename T>
+    void slot(slot_key id, T value)
+    {
+        (*this->_slots)[id] = std::make_shared<T>(std::move(value));
+    }
+
+    template <typename T>
+    [[nodiscard]] T* slot(slot_key id) const
+    {
+        if (this->_slots == nullptr)
+            return nullptr;
+
+        auto found = this->_slots->find(id);
+        if (found == this->_slots->end())
+            return nullptr;
+
+        return static_cast<T*>(found->second.get());
+    }
+
+private:
+    execution_context();
+
+private:
+    std::shared_ptr<slot_storage> _slots;
+};
+
+} // namespace fb
+
+#endif // !__EXECUTION_CONTEXT_H__

--- a/include/fb/game/builtin/server.h
+++ b/include/fb/game/builtin/server.h
@@ -50,7 +50,7 @@ struct server
     static int builtin_regex(lua_State* L);
     static int builtin_exp_multiplier(lua_State* L);
     static int builtin_drop_rate_multiplier(lua_State* L);
-    static int builtin_gv(lua_State* L);
+    static int builtin_property(lua_State* L);
 };
 
 } // namespace fb::game::builtin

--- a/include/fb/game/server.h
+++ b/include/fb/game/server.h
@@ -19,7 +19,7 @@
 #include <fb/game/service/system_storage.h>
 #include <fb/game/service/system_mail.h>
 #include <fb/game/service/schedule.h>
-#include <fb/game/service/vars.h>
+#include <fb/game/service/property.h>
 #include <fb/game/storage.h>
 #include <fb/game/system_storage_box.h>
 #include <fb/log_collector.h>
@@ -119,7 +119,7 @@ public:
     service::system_storage                system_storage;
     service::system_mail                   system_mail;
     service::schedule                      schedules;
-    service::vars                          vars;
+    service::property                      property;
 
 public:
     server(boost::asio::io_context& io_context, uint16_t port);

--- a/include/fb/game/service/property.h
+++ b/include/fb/game/service/property.h
@@ -1,5 +1,5 @@
-#ifndef __FB_GAME_SERVICE_VARS_H__
-#define __FB_GAME_SERVICE_VARS_H__
+#ifndef __FB_GAME_SERVICE_PROPERTY_H__
+#define __FB_GAME_SERVICE_PROPERTY_H__
 
 #include <fb/synchronized.h>
 #include <json/json.h>
@@ -8,7 +8,7 @@
 
 namespace fb::game::service {
 
-class vars
+class property
 {
 private:
     using storage = std::unordered_map<std::string, Json::Value>;

--- a/include/fb/thread.h
+++ b/include/fb/thread.h
@@ -8,8 +8,10 @@
 #include <queue>
 #include <stdexcept>
 #include <type_traits>
+#include <fb/execution_context.h>
 #include <fb/logger.h>
 #include <fb/timer.h>
+#include <async/propagation.h>
 #include <async/task.h>
 #include <async/task_completion_source.h>
 #include <async/awaitable_then.h>
@@ -73,17 +75,12 @@ private:
     void on_idle();
     void assert_exec() const;
 
-    static handle_error_type resolve_error(handle_error_type error)
-    {
-        if (error)
-            return error;
-
-        return [](std::exception&) {
-        };
-    }
-
     template <typename T, typename OnSuccess, typename OnFailure>
-    void run_retry_loop(handle_func_type<T>&& fn, size_t max_retries, OnSuccess&& on_success, OnFailure&& on_failure)
+    void run_retry_loop(handle_func_type<T>&&     fn,
+                        size_t                    max_retries,
+                        async::propagation::token context,
+                        OnSuccess&&               on_success,
+                        OnFailure&&               on_failure)
     {
         const auto     retry_limit = max_retries;
         auto           attempts    = std::make_shared<size_t>(0);
@@ -95,6 +92,7 @@ private:
                        this,
                        on_success = std::forward<OnSuccess>(on_success),
                        on_failure = std::forward<OnFailure>(on_failure)]() mutable {
+            execution_context::pending(context);
             async::awaitable_then((*fn_holder)(*this),
                                   [=,
                                    this,
@@ -171,7 +169,9 @@ private:
     }
 
     template <typename T>
-    async::task<T> dispatch_with_retry(handle_func_type<T>&& fn, size_t max_retries)
+    async::task<T> dispatch_with_retry(handle_func_type<T>&&     fn,
+                                       size_t                    max_retries,
+                                       async::propagation::token context = {})
     {
         auto promise = std::make_shared<async::task_completion_source<T>>();
 
@@ -180,6 +180,7 @@ private:
             this->run_retry_loop<T>(
                 std::move(fn),
                 max_retries,
+                std::move(context),
                 [promise]() {
                     promise->set_value();
                 },
@@ -192,6 +193,7 @@ private:
             this->run_retry_loop<T>(
                 std::move(fn),
                 max_retries,
+                std::move(context),
                 [promise](T&& value) {
                     promise->set_value(std::move(value));
                 },
@@ -204,16 +206,18 @@ private:
     }
 
     template <typename T>
-    void enqueue_with_retry(handle_func_type<T>&& fn,
-                            size_t                max_retries,
-                            handle_error_type     error,
-                            std::function<void()> on_complete)
+    void enqueue_with_retry(handle_func_type<T>&&     fn,
+                            size_t                    max_retries,
+                            handle_error_type         error,
+                            std::function<void()>     on_complete,
+                            async::propagation::token context = {})
     {
         if constexpr (std::is_same_v<T, void>)
         {
             this->run_retry_loop<T>(
                 std::move(fn),
                 max_retries,
+                std::move(context),
                 [on_complete = std::move(on_complete)]() {
                     if (on_complete)
                         on_complete();
@@ -225,6 +229,7 @@ private:
             this->run_retry_loop<T>(
                 std::move(fn),
                 max_retries,
+                std::move(context),
                 [on_complete = std::move(on_complete)](T&&) {
                     if (on_complete)
                         on_complete();
@@ -234,6 +239,15 @@ private:
     }
 
 public:
+    static handle_error_type on_error(handle_error_type handler)
+    {
+        if (handler)
+            return handler;
+
+        return [](std::exception&) {
+        };
+    }
+
     std::thread::id            id() const;
     uint8_t                    index() const;
     void                       join();
@@ -267,15 +281,24 @@ public:
         return builder<T>(*this);
     }
 
-    void enqueue(handle_func_type<void>&& fn, handle_error_type&& error, std::function<void()>&& callback);
+    void enqueue(handle_func_type<void>&&  fn,
+                 handle_error_type&&       error,
+                 std::function<void()>&&   callback,
+                 async::propagation::token context = {});
 
     template <typename ReturnType> void enqueue(handle_func_type<ReturnType>&&      fn,
                                                 handle_error_type&&                 error,
-                                                std::function<void(ReturnType&&)>&& callback)
+                                                std::function<void(ReturnType&&)>&& callback,
+                                                async::propagation::token           context = {})
     {
         auto  guard = this->_queue.enter_write();
         auto& queue = guard.value();
-        queue.push([fn = std::move(fn), error = std::move(error), callback = std::move(callback), this]() {
+        queue.push([fn       = std::move(fn),
+                    error    = std::move(error),
+                    callback = std::move(callback),
+                    context  = std::move(context),
+                    this]() {
+            execution_context::pending(context);
             async::awaitable_then(fn(*this),
                                   [fn = std::move(fn), error = std::move(error), callback = std::move(callback)](
                                       async::awaitable_result<ReturnType> result) {
@@ -305,7 +328,8 @@ public:
         });
     }
 
-    template <typename ReturnType> async::task<ReturnType> dispatch(handle_func_type<ReturnType>&& fn)
+    template <typename ReturnType> async::task<ReturnType> dispatch(handle_func_type<ReturnType>&& fn,
+                                                                    async::propagation::token      context = {})
     {
         auto promise = std::make_shared<async::task_completion_source<ReturnType>>();
         this->enqueue<ReturnType>(
@@ -315,11 +339,12 @@ public:
             },
             [promise](ReturnType&& value) {
                 promise->set_value(value);
-            });
+            },
+            std::move(context));
         return promise->task();
     }
 
-    [[nodiscard]] async::task<void> dispatch(handle_func_type<void>&& fn);
+    [[nodiscard]] async::task<void> dispatch(handle_func_type<void>&& fn, async::propagation::token context = {});
     [[nodiscard]] async::task<void> switching();
     size_t                          queue_size() const;
     std::string                     to_string() const;
@@ -334,33 +359,43 @@ private:
     thread& _thread;
 
 public:
-    handle_func_type<T>   func;
-    handle_error_type     on_error;
-    std::function<void()> on_complete;
-    size_t                retry_count = 0;
+    handle_func_type<T>       func;
+    handle_error_type         on_error;
+    std::function<void()>     on_complete;
+    size_t                    retry_count = 0;
+    async::propagation::token context;
 
     void enqueue()
     {
         if (this->func == nullptr)
             throw std::runtime_error("thread builder: func is not set");
 
-        auto error    = thread::resolve_error(std::move(this->on_error));
+        auto resolved = execution_context::token(this->context);
+        auto error    = thread::on_error(std::move(this->on_error));
         auto complete = this->on_complete ? std::move(this->on_complete) : std::function<void()>{};
 
         if (this->retry_count > 0)
         {
-            this->_thread.enqueue_with_retry<T>(std::move(this->func), this->retry_count, error, std::move(complete));
+            this->_thread.enqueue_with_retry<T>(std::move(this->func),
+                                                this->retry_count,
+                                                error,
+                                                std::move(complete),
+                                                std::move(resolved));
         }
         else if constexpr (std::is_same_v<T, void>)
         {
-            this->_thread.enqueue(std::move(this->func), std::move(error), std::move(complete));
+            this->_thread.enqueue(std::move(this->func), std::move(error), std::move(complete), std::move(resolved));
         }
         else
         {
-            this->_thread.enqueue<T>(std::move(this->func), std::move(error), [complete = std::move(complete)](T&&) {
-                if (complete)
-                    complete();
-            });
+            this->_thread.enqueue<T>(
+                std::move(this->func),
+                std::move(error),
+                [complete = std::move(complete)](T&&) {
+                    if (complete)
+                        complete();
+                },
+                std::move(resolved));
         }
     }
 
@@ -369,15 +404,17 @@ public:
         if (this->func == nullptr)
             throw std::runtime_error("thread builder: func is not set");
 
+        auto resolved = execution_context::token(this->context);
+
         if (this->retry_count > 0)
         {
-            return this->_thread.dispatch_with_retry<T>(std::move(this->func), this->retry_count);
+            return this->_thread.dispatch_with_retry<T>(std::move(this->func), this->retry_count, std::move(resolved));
         }
 
         if constexpr (std::is_same_v<T, void>)
-            return this->_thread.dispatch(std::move(this->func));
+            return this->_thread.dispatch(std::move(this->func), std::move(resolved));
         else
-            return this->_thread.dispatch<T>(std::move(this->func));
+            return this->_thread.dispatch<T>(std::move(this->func), std::move(resolved));
     }
 
     explicit builder(thread& owner) :

--- a/include/fb/thread_container.h
+++ b/include/fb/thread_container.h
@@ -3,6 +3,8 @@
 
 #include <boost/asio.hpp>
 #include <coroutine>
+#include <async/propagation.h>
+#include <fb/execution_context.h>
 #include <fb/thread.h>
 #include <fb/timer.h>
 #include <fb/thread_switchable.h>
@@ -71,6 +73,7 @@ public:
         builder.func = [](auto&) -> async::task<void> {
             co_return;
         };
+        builder.context = execution_context::token();
         co_return co_await builder.dispatch();
     }
 
@@ -87,17 +90,8 @@ public:
     const_iterator cend() const;
 
 private:
-    static thread::handle_error_type resolve_error(thread::handle_error_type error)
-    {
-        if (error)
-            return error;
-
-        return [](std::exception&) {
-        };
-    }
-
     template <typename PivotT>
-    fb::thread* resolve_thread(const std::weak_ptr<PivotT>& pivot) const
+    fb::thread* thread_for(const std::weak_ptr<PivotT>& pivot) const
     {
         static_assert(std::is_base_of_v<thread_switchable, PivotT>, "PivotT must be a thread_switchable");
 
@@ -128,20 +122,22 @@ public:
     thread::handle_error_type        on_error;
     std::function<void()>            on_complete;
     size_t                           retry_count = 0;
+    async::propagation::token        context;
 
     void enqueue()
     {
         if (this->func == nullptr)
             throw std::runtime_error("thread container builder: func is not set");
 
-        auto* target = this->_container.resolve_thread<PivotT>(this->_pivot);
+        auto* target = this->_container.thread_for<PivotT>(this->_pivot);
         auto  wrapped =
             this->make_wrapped_func(std::make_shared<thread::handle_func_type<T>>(std::move(this->func)), true);
 
         auto inner        = target->template new_builder<T>();
         inner.func        = std::move(wrapped);
         inner.retry_count = this->retry_count;
-        inner.on_error    = thread_container::resolve_error(std::move(this->on_error));
+        inner.context     = this->context;
+        inner.on_error    = thread::on_error(std::move(this->on_error));
         inner.on_complete = std::move(this->on_complete);
         inner.enqueue();
     }
@@ -172,6 +168,8 @@ public:
                 if (when_fn(*target_thread) == false)
                     throw std::runtime_error("condition not satisfied");
 
+                execution_context::pending(this->context);
+
                 if constexpr (std::is_same_v<T, void>)
                 {
                     co_await this->func(*target_thread);
@@ -200,6 +198,7 @@ public:
         auto inner        = target_thread->template new_builder<T>();
         inner.func        = std::move(wrapped);
         inner.retry_count = this->retry_count;
+        inner.context     = this->context;
         co_return co_await inner.dispatch();
     }
 
@@ -212,13 +211,13 @@ private:
     thread::handle_func_type<T> make_wrapped_func(std::shared_ptr<thread::handle_func_type<T>> fn_holder,
                                                   bool                                         for_enqueue) const
     {
-        auto when_fn = this->when ? this->when : std::function<bool(fb::thread&)>([](auto&) {
+        auto when_fn            = this->when ? this->when : std::function<bool(fb::thread&)>([](auto&) {
             return true;
         });
-        auto on_error_holder =
-            std::make_shared<thread::handle_error_type>(thread_container::resolve_error(this->on_error));
+        auto on_error_holder    = std::make_shared<thread::handle_error_type>(thread::on_error(this->on_error));
         auto on_complete_holder = std::make_shared<std::function<void()>>(this->on_complete);
         auto retry_count        = this->retry_count;
+        auto context            = this->context;
 
         return [container = &this->_container,
                 pivot     = this->_pivot,
@@ -227,6 +226,7 @@ private:
                 on_error_holder,
                 on_complete_holder,
                 retry_count,
+                context,
                 for_enqueue](fb::thread& thread) mutable -> async::task<T> {
             auto shared = pivot.lock();
             if (shared == nullptr)
@@ -244,6 +244,7 @@ private:
                 retry.on_error    = *on_error_holder;
                 retry.on_complete = on_complete_holder ? *on_complete_holder : std::function<void()>{};
                 retry.retry_count = retry_count;
+                retry.context     = context;
 
                 if (for_enqueue)
                 {

--- a/include/fb/timer.h
+++ b/include/fb/timer.h
@@ -4,6 +4,7 @@
 #include <fb/model/datetime.h>
 #include <chrono>
 #include <functional>
+#include <async/propagation.h>
 #include <async/task.h>
 #include <thread>
 
@@ -32,13 +33,17 @@ private:
     bool _canceled = false;
 
 public:
-    const handle_callback_type fn;
-    const fb::model::timespan  duration;
-    const repeat_type          repeat;
-    fb::model::datetime        begin;
+    const handle_callback_type      fn;
+    const fb::model::timespan       duration;
+    const repeat_type               repeat;
+    const async::propagation::token context;
+    fb::model::datetime             begin;
 
 private:
-    timer(const handle_callback_type& fn, const fb::model::timespan& duration, repeat_type repeat);
+    timer(const handle_callback_type& fn,
+          const fb::model::timespan&  duration,
+          repeat_type                 repeat,
+          async::propagation::token   context);
     timer(const timer&)             = delete;
     timer(timer&&)                  = delete;
     timer& operator= (timer&)       = delete;

--- a/infra/db/latest.sql
+++ b/infra/db/latest.sql
@@ -421,10 +421,12 @@ CREATE TABLE `log` (
   `event` varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,
   `server_id` varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,
   `server_name` varchar(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,
+  `transaction_id` varchar(64) DEFAULT NULL,
   `data` json NOT NULL,
   `created_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   KEY `idx_log_timestamp` (`timestamp`),
-  KEY `idx_log_server_id` (`server_id`)
+  KEY `idx_log_server_id` (`server_id`),
+  KEY `idx_log_transaction_id` (`transaction_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/server/bot/config/config.dev.json
+++ b/server/bot/config/config.dev.json
@@ -7,8 +7,8 @@
 			"fatal"
 		]
 	},
-	"ip": "192.168.0.180",
-	"port": 30000,
+	"ip": "127.0.0.1",
+	"port": 3001,
 	"io_size": 1,
 	"interval": 1000,
 	"spawn_per_interval": 1,

--- a/server/fb/Dockerfile
+++ b/server/fb/Dockerfile
@@ -53,9 +53,9 @@ RUN cmake --build . --config Release --parallel 32
 RUN make install
 
 WORKDIR /app
-RUN git clone https://github.com/microsoft/cpp-async
+RUN git clone https://github.com/boyism80/cpp-async
 WORKDIR /app/cpp-async
-RUN git checkout v1.1.0
+RUN git checkout v1.1.0-fb
 RUN cp -r /app/cpp-async/include/async /usr/local/include/async
 
 WORKDIR /app

--- a/server/fb/src/amqp.queue.cpp
+++ b/server/fb/src/amqp.queue.cpp
@@ -1,4 +1,6 @@
 #include <fb/amqp/queue.h>
+#include <fb/context.h>
+#include <fb/execution_context.h>
 
 using namespace fb::amqp;
 
@@ -87,6 +89,9 @@ void queue::invoke_async(const std::vector<uint8_t>& message)
     if (target_thread == nullptr)
     {
         // Fallback to synchronous invoke if no thread available
+        auto frame = fb::execution_context::create();
+        frame->slot(fb::context::local::slot_id(), fb::context{.transaction_id = fb::mint_transaction_id()});
+        fb::execution_context::pending(fb::execution_context::token(std::move(frame)));
         async::awaitable_then(this->invoke(message), [](async::awaitable_result<void> result) {
             // work done
             try
@@ -107,7 +112,10 @@ void queue::invoke_async(const std::vector<uint8_t>& message)
     {
         // Enqueue to the least loaded thread
         auto builder = target_thread->new_builder<void>();
-        builder.func = [message, this](auto& thread) -> async::task<void> {
+        auto frame   = fb::execution_context::create();
+        frame->slot(fb::context::local::slot_id(), fb::context{.transaction_id = fb::mint_transaction_id()});
+        builder.context = fb::execution_context::token(std::move(frame));
+        builder.func    = [message, this](auto& thread) -> async::task<void> {
             co_await this->invoke(message);
         };
         builder.on_error = [](std::exception& e) {

--- a/server/fb/src/async_executor.cpp
+++ b/server/fb/src/async_executor.cpp
@@ -1,4 +1,5 @@
 #include <fb/async_executor.h>
+#include <fb/execution_context.h>
 
 using namespace fb;
 
@@ -6,6 +7,7 @@ async_executor::async_executor(boost::asio::io_context& context, std::string_vie
     io_context(context),
     threads(*this, thread_count)
 {
+    execution_context::install_propagation_hooks(*this);
     static auto flag = std::once_flag{};
     std::call_once(flag, [name] {
         auto name_str = std::string(name);

--- a/server/fb/src/execution_context.cpp
+++ b/server/fb/src/execution_context.cpp
@@ -1,0 +1,83 @@
+#include <fb/async_executor.h>
+#include <fb/execution_context.h>
+
+using namespace fb;
+
+namespace {
+
+thread_local std::shared_ptr<execution_context> active_frame;
+
+} // namespace
+
+execution_context::execution_context() :
+    _slots(std::make_shared<slot_storage>())
+{ }
+
+std::shared_ptr<execution_context> execution_context::create()
+{
+    return std::shared_ptr<execution_context>(new execution_context());
+}
+
+std::shared_ptr<execution_context> execution_context::current()
+{
+    return frame(token());
+}
+
+std::shared_ptr<execution_context> execution_context::active()
+{
+    return active_frame;
+}
+
+void execution_context::active(std::shared_ptr<execution_context> value)
+{
+    active_frame = std::move(value);
+}
+
+async::propagation::token execution_context::token()
+{
+    return async::propagation::capture();
+}
+
+async::propagation::token execution_context::token(async::propagation::token value)
+{
+    if (value)
+        return value;
+
+    return token();
+}
+
+async::propagation::token execution_context::token(std::shared_ptr<execution_context> value)
+{
+    return std::static_pointer_cast<void>(std::move(value));
+}
+
+std::shared_ptr<execution_context> execution_context::frame(async::propagation::token value)
+{
+    if (value == nullptr)
+        return nullptr;
+
+    return std::static_pointer_cast<execution_context>(value);
+}
+
+void execution_context::pending(async::propagation::token value)
+{
+    if (value)
+        async::propagation::set_pending(std::move(value));
+}
+
+void execution_context::install_propagation_hooks(async_executor&)
+{
+    auto& hooks = async::propagation::runtime();
+
+    hooks.capture = []() -> async::propagation::token {
+        return token(active());
+    };
+
+    hooks.install = [](async::propagation::token value) {
+        active(frame(std::move(value)));
+    };
+
+    hooks.restore = [](async::propagation::token value) {
+        active(frame(std::move(value)));
+    };
+}

--- a/server/fb/src/log_collector.cpp
+++ b/server/fb/src/log_collector.cpp
@@ -1,4 +1,5 @@
 #include <fb/log_collector.h>
+#include <fb/context.h>
 #include <fb/amqp.h>
 #include <fb/logger.h>
 #include <fb/model/datetime.h>
@@ -48,6 +49,9 @@ void log_collector::write(std::string_view event_type, const Json::Value& data)
         entry["server_id"]   = this->_server_id;
         entry["server_name"] = this->_server_name;
         entry["data"]        = data;
+
+        if (auto* ctx = context::local::try_get())
+            entry["transaction_id"] = ctx->transaction_id;
 
         std::lock_guard<std::mutex> lock(this->_buffer_mutex);
         this->_buffer.push_back(std::move(entry));

--- a/server/fb/src/lua.cpp
+++ b/server/fb/src/lua.cpp
@@ -1,7 +1,9 @@
 #include <fb/async_executor.h>
+#include <fb/execution_context.h>
 #include <fb/lua.h>
 #include <fb/thread_container.h>
 #include <async/awaitable_then.h>
+#include <async/propagation.h>
 
 using namespace fb::lua;
 
@@ -392,9 +394,13 @@ void fb::lua::context::resume(int argc, int* n)
 
         if (parent != nullptr && lua_status(*parent) == LUA_YIELD)
         {
-            async::awaitable_then(parent->_initial_thread.switching(), [=](auto result) {
-                parent->resume(0);
-            });
+            auto context = fb::execution_context::token();
+            async::awaitable_then(parent->_initial_thread.switching(),
+                                  [parent, context](async::awaitable_result<void> result) {
+                                      result();
+                                      fb::execution_context::pending(context);
+                                      parent->resume(0);
+                                  });
         }
         promise->set_exception(std::make_exception_ptr(std::runtime_error(message)));
     }
@@ -403,15 +409,20 @@ void fb::lua::context::resume(int argc, int* n)
         auto parent = this->_parent;
         if (parent != nullptr)
         {
-            async::awaitable_then(parent->_initial_thread.switching(), [=, this](auto result) {
-                auto argc = this->argc();
-                if (n != nullptr)
-                    *n = argc;
+            auto context = fb::execution_context::token();
+            async::awaitable_then(parent->_initial_thread.switching(),
+                                  [this, parent, n, context](async::awaitable_result<void> result) {
+                                      result();
+                                      fb::execution_context::pending(context);
 
-                lua_xmove(*this, *parent, argc);
-                if (lua_status(*parent) == LUA_YIELD)
-                    parent->resume(argc);
-            });
+                                      auto argc = this->argc();
+                                      if (n != nullptr)
+                                          *n = argc;
+
+                                      lua_xmove(*this, *parent, argc);
+                                      if (lua_status(*parent) == LUA_YIELD)
+                                          parent->resume(argc);
+                                  });
         }
         if (this->_auto_release)
             root->release(*this);
@@ -457,19 +468,22 @@ int context::ensure_yield(fb::async_executor&                  executor,
     }
     else
     {
-        async::awaitable_then(executor.threads.switching(weak), [this, fn](auto result) {
-            try
-            {
-                result();
-                return fn(true);
-            }
-            catch (std::exception& e)
-            {
-                fb::logger::fatal("lua error message : {}", e.what());
-                this->release();
-                return 0;
-            }
-        });
+        auto context = fb::execution_context::token();
+        async::awaitable_then(executor.threads.switching(weak),
+                              [this, fn, context](async::awaitable_result<void> result) {
+                                  try
+                                  {
+                                      result();
+                                      fb::execution_context::pending(context);
+                                      return fn(true);
+                                  }
+                                  catch (std::exception& e)
+                                  {
+                                      fb::logger::fatal("lua error message : {}", e.what());
+                                      this->release();
+                                      return 0;
+                                  }
+                              });
         if (no_yield)
             return 0;
         else
@@ -501,24 +515,27 @@ int fb::lua::context::ensure_resume(fb::async_executor&                  executo
     }
     else
     {
-        async::awaitable_then(this->_initial_thread.switching(), [this, fn, &executor, weak](auto result) {
-            try
-            {
-                result();
+        auto context = fb::execution_context::token();
+        async::awaitable_then(this->_initial_thread.switching(),
+                              [this, fn, weak, context](async::awaitable_result<void> result) {
+                                  try
+                                  {
+                                      result();
 
-                auto shared = weak.lock();
-                if (shared == nullptr)
-                    throw std::runtime_error("object not alive");
+                                      auto shared = weak.lock();
+                                      if (shared == nullptr)
+                                          throw std::runtime_error("object not alive");
 
-                auto n = fn();
-                this->resume(n);
-            }
-            catch (std::exception& e)
-            {
-                fb::logger::fatal("lua error message : {}", e.what());
-                this->release();
-            }
-        });
+                                      fb::execution_context::pending(context);
+                                      auto n = fn();
+                                      this->resume(n);
+                                  }
+                                  catch (std::exception& e)
+                                  {
+                                      fb::logger::fatal("lua error message : {}", e.what());
+                                      this->release();
+                                  }
+                              });
         return 0;
     }
 }

--- a/server/fb/src/thread.cpp
+++ b/server/fb/src/thread.cpp
@@ -1,3 +1,4 @@
+#include <fb/execution_context.h>
 #include <fb/thread.h>
 #include <sstream>
 
@@ -63,6 +64,7 @@ void fb::thread::on_idle()
 
         auto repeat = timer->repeat;
         auto fn     = fb::timer::handle_callback_type{timer->fn};
+        execution_context::pending(timer->context);
         async::awaitable_then(fn(now, this->_thread.get_id()), [timer, repeat, now](auto result) {
             if (repeat == fb::timer::repeat_type::repeat)
                 timer->begin = now;
@@ -104,7 +106,8 @@ std::shared_ptr<fb::timer> fb::thread::settimer(fb::timer::handle_callback_type&
                                              boost::stacktrace::to_string(boost::stacktrace::stacktrace())));
     }
 
-    auto ptr = new fb::timer(
+    auto snapshot = execution_context::token();
+    auto ptr      = new fb::timer(
         [this, fn](const fb::model::datetime&, std::thread::id) -> async::task<void> {
             auto index = this->_index;
             try
@@ -118,7 +121,8 @@ std::shared_ptr<fb::timer> fb::thread::settimer(fb::timer::handle_callback_type&
             co_return;
         },
         duration,
-        repeat);
+        repeat,
+        std::move(snapshot));
 
     auto shared_ptr = std::shared_ptr<fb::timer>(ptr);
     this->_timers.push_back(shared_ptr);
@@ -139,11 +143,19 @@ async::task<void> fb::thread::sleep(const fb::model::timespan& delay)
     return promise->task();
 }
 
-void fb::thread::enqueue(handle_func_type<void>&& fn, handle_error_type&& error, std::function<void()>&& callback)
+void fb::thread::enqueue(handle_func_type<void>&&  fn,
+                         handle_error_type&&       error,
+                         std::function<void()>&&   callback,
+                         async::propagation::token context)
 {
     auto  guard = this->_queue.enter_write();
     auto& queue = guard.value();
-    queue.push([fn = std::move(fn), error = std::move(error), callback = std::move(callback), this]() {
+    queue.push([fn       = std::move(fn),
+                error    = std::move(error),
+                callback = std::move(callback),
+                context  = std::move(context),
+                this]() {
+        execution_context::pending(context);
         async::awaitable_then(fn(*this),
                               [fn = std::move(fn), error = std::move(error), callback = std::move(callback)](
                                   async::awaitable_result<void> result) {
@@ -172,11 +184,12 @@ void fb::thread::enqueue(handle_func_type<void>&& fn, handle_error_type&& error,
     });
 }
 
-async::task<void> fb::thread::dispatch(handle_func_type<void>&& fn)
+async::task<void> fb::thread::dispatch(handle_func_type<void>&& fn, async::propagation::token context)
 {
     auto promise = std::make_shared<async::task_completion_source<void>>();
     if (this->id() == std::this_thread::get_id())
     {
+        execution_context::pending(context);
         async::awaitable_then(fn(*this), [promise](auto result) {
             try
             {
@@ -202,7 +215,8 @@ async::task<void> fb::thread::dispatch(handle_func_type<void>&& fn)
             },
             [promise]() {
                 promise->set_value();
-            });
+            },
+            std::move(context));
     }
 
     return promise->task();

--- a/server/fb/src/timer.cpp
+++ b/server/fb/src/timer.cpp
@@ -2,8 +2,12 @@
 
 using namespace fb;
 
-timer::timer(const handle_callback_type& fn, const fb::model::timespan& duration, repeat_type repeat) :
+timer::timer(const handle_callback_type& fn,
+             const fb::model::timespan&  duration,
+             repeat_type                 repeat,
+             async::propagation::token   context) :
     fn(fn),
     duration(duration),
-    repeat(repeat)
+    repeat(repeat),
+    context(std::move(context))
 { }

--- a/server/game/scripts/command.lua
+++ b/server/game/scripts/command.lua
@@ -826,7 +826,7 @@ command_funcs = {
             ['privilege'] = ROLE.ADMIN,
             ['usage'] = '- 현재 셔플 기준 천상미궁시작~천상미궁비밀방 루트를 메시지로 출력',
             ['command'] = function (me, args)
-                if gv("sky_maze_0") == nil then
+                if property("sky_maze_0") == nil then
                     sky_maze_shuffle()
                 end
                 

--- a/server/game/scripts/init.lua
+++ b/server/game/scripts/init.lua
@@ -1,9 +1,9 @@
 -- Runs once when the game server finishes starting.
--- Use gv(key, value) to set server-wide globals (string, number, or boolean).
--- Other scripts can read them with gv(key).
+-- Use property(key, value) to set server-wide properties (string, number, or boolean).
+-- Other scripts can read them with property(key).
 
 -- Initial battery stock for 시계장인 (restocked daily at 18:00 by ON_SCHEDULE_2)
-gv("clock_time_item", 10)
+property("clock_time_item", 10)
 
 sky_maze_shuffle()
 pk_sky_maze_shuffle()

--- a/server/game/scripts/npc/남북무한도우미.lua
+++ b/server/game/scripts/npc/남북무한도우미.lua
@@ -58,9 +58,9 @@ function NPC_499(me, npc)
     end
 
     if sel == 3 then
-        local ns_start = gv("ns_start")
+        local ns_start = property("ns_start")
         if ns_start == 2 then
-            local winner = gv("ns_winner_team")
+            local winner = property("ns_winner_team")
             me:dialog(npc, "승리팀 상품 수령은 대전 종료 후 해당 기능이 연동되면 이용하실 수 있습니다.", false, true)
         else
             me:dialog(npc, "수령할 상품이 없습니다. 남북무한대전에 참가하고 승리한 뒤 이용해 주세요.", false, true)

--- a/server/game/scripts/npc/남팀워프.lua
+++ b/server/game/scripts/npc/남팀워프.lua
@@ -1,5 +1,5 @@
 function NPC_501(me, npc)
-    if gv("ns_start") ~= 1 then
+    if property("ns_start") ~= 1 then
         me:dialog(npc, "저런, 남북무한대전은 종료되었는데요. 나가는걸 도와드릴게요.", false, false)
         local map = name2map("국내성")
         if map then

--- a/server/game/scripts/npc/바람돌이.lua
+++ b/server/game/scripts/npc/바람돌이.lua
@@ -1,5 +1,5 @@
 function NPC_497(me, npc)
-    if gv("sesi_rightnow") ~= 1 then
+    if property("sesi_rightnow") ~= 1 then
         me:dialog(npc, "......", false, false)
         return
     end

--- a/server/game/scripts/npc/백나연.lua
+++ b/server/game/scripts/npc/백나연.lua
@@ -4,7 +4,7 @@ function NPC_354(me, npc)
         return
     end
 
-    if gv("sesi_rightnow") ~= 2 then
+    if property("sesi_rightnow") ~= 2 then
         return
     end
 

--- a/server/game/scripts/npc/백남인.lua
+++ b/server/game/scripts/npc/백남인.lua
@@ -1,6 +1,6 @@
 
 function NPC_502(me, npc)
-    local sesi = gv("sesi_rightnow")
+    local sesi = property("sesi_rightnow")
     if sesi == 1 then
         local sel, list_btn = me:list(npc, " 어쩐일로 찾아오셨습니까?", {
             "정월 대보름이 뭐에요?",

--- a/server/game/scripts/npc/백리향.lua
+++ b/server/game/scripts/npc/백리향.lua
@@ -78,7 +78,7 @@ function NPC_363(me, npc)
         return
     end
 
-    if gv("sesi_rightnow") ~= 8 then
+    if property("sesi_rightnow") ~= 8 then
         return
     end
 

--- a/server/game/scripts/npc/백몽연.lua
+++ b/server/game/scripts/npc/백몽연.lua
@@ -6,7 +6,7 @@ function NPC_353(me, npc)
         return
     end
 
-    if gv("sesi_rightnow") ~= 2 then
+    if property("sesi_rightnow") ~= 2 then
         return
     end
 

--- a/server/game/scripts/npc/백세인.lua
+++ b/server/game/scripts/npc/백세인.lua
@@ -4,7 +4,7 @@ function NPC_357(me, npc)
         return
     end
 
-    if gv("sesi_rightnow") ~= 2 then
+    if property("sesi_rightnow") ~= 2 then
         me:dialog(npc, "준비중입니다.", false, false)
         return
     end

--- a/server/game/scripts/npc/백수인.lua
+++ b/server/game/scripts/npc/백수인.lua
@@ -4,7 +4,7 @@ function NPC_548(me, npc)
         return
     end
 
-    if gv("sesi_rightnow") ~= 2 then
+    if property("sesi_rightnow") ~= 2 then
         me:dialog(npc, "준비중입니다.", false, false)
         return
     end

--- a/server/game/scripts/npc/백주연.lua
+++ b/server/game/scripts/npc/백주연.lua
@@ -4,7 +4,7 @@ function NPC_361(me, npc)
         return
     end
 
-    if gv("sesi_rightnow") ~= 2 then
+    if property("sesi_rightnow") ~= 2 then
         me:dialog(npc, "준비중입니다.", false, false)
         return
     end

--- a/server/game/scripts/npc/북팀워프.lua
+++ b/server/game/scripts/npc/북팀워프.lua
@@ -1,5 +1,5 @@
 function NPC_500(me, npc)
-    if gv("ns_start") ~= 1 then
+    if property("ns_start") ~= 1 then
         me:dialog(npc, "저런, 남북무한대전은 종료되었는데요. 나가는걸 도와드릴게요.", false, false)
         local map = name2map("국내성")
         if map then

--- a/server/game/scripts/npc/사용자오엑스.lua
+++ b/server/game/scripts/npc/사용자오엑스.lua
@@ -27,7 +27,7 @@ function NPC_309(me, npc)
     end
 
     if sel == 2 then
-        if gv("oxquiz_open") == 1 then
+        if property("oxquiz_open") == 1 then
             local map = name2map("OX퀴즈장")
             if map then
                 me:map(map, math.random(13, 15), math.random(2, 4))

--- a/server/game/scripts/npc/시계장인.lua
+++ b/server/game/scripts/npc/시계장인.lua
@@ -37,7 +37,7 @@ local function run_clock_purchase(me, npc)
 end
 
 local function run_battery_purchase(me, npc)
-    local stock = gv("clock_time_item")
+    local stock = property("clock_time_item")
     if stock == nil then
         stock = 0
     end
@@ -69,7 +69,7 @@ local function run_battery_purchase(me, npc)
         me:dialog(npc, '소지품이 가득 차서 건전지를 줄 수 없네.', false, false)
         return
     end
-    gv("clock_time_item", stock - 1)
+    property("clock_time_item", stock - 1)
     me:dialog(npc, '자네 생각보다 운이 좋은걸? 여기 건전기 가져가게나.', false, false)
 end
 

--- a/server/game/scripts/npc/어리버리한곰.lua
+++ b/server/game/scripts/npc/어리버리한곰.lua
@@ -1,6 +1,6 @@
 
 function NPC_460(me, npc)
-    if gv("check") == 25 and me:has_items("훈제연어", 5) then
+    if property("check") == 25 and me:has_items("훈제연어", 5) then
         local btn = me:dialog(npc, "난 깊은계곡을 지키고 있는 곰이다웅... 그런데 너는 보니까 임무를 수행중인것처럼 보이는데웅...?", false, true)
         if btn == DIALOG_RESULT.QUIT then
             return

--- a/server/game/scripts/npc/영문스님.lua
+++ b/server/game/scripts/npc/영문스님.lua
@@ -5,7 +5,7 @@ function NPC_365(me, npc)
         return
     end
 
-    if gv("sesi_rightnow") ~= 4 then
+    if property("sesi_rightnow") ~= 4 then
         return
     end
 

--- a/server/game/scripts/npc/오단미.lua
+++ b/server/game/scripts/npc/오단미.lua
@@ -1,6 +1,6 @@
 
 function NPC_355(me, npc)
-    if gv("sesi_rightnow") ~= 5 then
+    if property("sesi_rightnow") ~= 5 then
         local btn = me:dialog(npc, "안녕하세요? 저는 오단미입니다.", false, true)
         if btn == DIALOG_RESULT.QUIT then
             return

--- a/server/game/scripts/npc/오선릉.lua
+++ b/server/game/scripts/npc/오선릉.lua
@@ -4,7 +4,7 @@ function NPC_362(me, npc)
         return
     end
 
-    if gv("sesi_rightnow") ~= 2 then
+    if property("sesi_rightnow") ~= 2 then
         me:dialog(npc, "준비중입니다.", false, false)
         return
     end

--- a/server/game/scripts/npc/장명주.lua
+++ b/server/game/scripts/npc/장명주.lua
@@ -15,7 +15,7 @@ function NPC_359(me, npc)
         return
     end
 
-    if gv("sesi_rightnow") ~= 3 then
+    if property("sesi_rightnow") ~= 3 then
         return
     end
 

--- a/server/game/scripts/npc/정어언.lua
+++ b/server/game/scripts/npc/정어언.lua
@@ -4,7 +4,7 @@ function NPC_356(me, npc)
         return
     end
 
-    if gv("sesi_rightnow") ~= 2 then
+    if property("sesi_rightnow") ~= 2 then
         me:dialog(npc, "준비중입니다.", false, false)
         return
     end

--- a/server/game/scripts/npc/촌장부인.lua
+++ b/server/game/scripts/npc/촌장부인.lua
@@ -1,6 +1,6 @@
 
 local function run_sesi_2(me, npc)
-    if gv("sesi_rightnow") ~= 2 then
+    if property("sesi_rightnow") ~= 2 then
         return false
     end
     local quest = me:quest(QUEST_BAEK_MONGYEON)
@@ -27,7 +27,7 @@ local function run_sesi_2(me, npc)
 end
 
 local function run_sesi_4(me, npc)
-    if gv("sesi_rightnow") ~= 4 then
+    if property("sesi_rightnow") ~= 4 then
         return false
     end
     if me:has_items("색비단", 1) then
@@ -47,7 +47,7 @@ local function run_sesi_4(me, npc)
 end
 
 local function run_sesi_5(me, npc)
-    if gv("sesi_rightnow") ~= 5 then
+    if property("sesi_rightnow") ~= 5 then
         return false
     end
     local btn = me:dialog(npc, "창포가 필요하시다구요.. 제가 모아놓은 창포를 드리도록 하죠.", false, true)
@@ -86,7 +86,7 @@ local function run_sesi_5(me, npc)
 end
 
 local function run_sesi_7(me, npc)
-    if gv("sesi_rightnow") ~= 7 then
+    if property("sesi_rightnow") ~= 7 then
         return false
     end
     local sel, list_btn = me:list(npc, "무슨일로 오셨나요?", { "그물이 필요해요..", "식용호박이 필요해요..." }, false)
@@ -121,7 +121,7 @@ local function run_sesi_7(me, npc)
 end
 
 local function run_sesi_8(me, npc)
-    if gv("sesi_rightnow") ~= 8 then
+    if property("sesi_rightnow") ~= 8 then
         return false
     end
     local quest = me:quest(QUEST_BAEKRIHYANG)

--- a/server/game/scripts/npc/출발도우미.lua
+++ b/server/game/scripts/npc/출발도우미.lua
@@ -36,26 +36,26 @@ function NPC_495(me, npc)
     end
 
     if map_id == MAP_ID_FINISH then
-        local rank = gv("surviverun_rank")
+        local rank = property("surviverun_rank")
         if rank == nil or rank == 0 then
             rank = 1
         end
         local prize_name = "노란비서"
         if rank == 1 then
-            prize_name = gv("survive_prize_1") or prize_name
+            prize_name = property("survive_prize_1") or prize_name
         elseif rank == 2 then
-            prize_name = gv("survive_prize_2") or prize_name
+            prize_name = property("survive_prize_2") or prize_name
         elseif rank <= 10 then
-            prize_name = gv("survive_prize_10") or prize_name
+            prize_name = property("survive_prize_10") or prize_name
         else
-            prize_name = gv("survive_prize_joiner") or prize_name
+            prize_name = property("survive_prize_joiner") or prize_name
         end
         local btn = me:dialog(npc, "축하합니다! " .. me:name() .. "님은 " .. tostring(rank) .. "등으로 완주하여 상품으로 " .. prize_name .. "을(를) 받으실 수 있습니다.", false, false)
         if btn == DIALOG_RESULT.QUIT then
             return
         end
         if me:mkitem(prize_name, 1) ~= nil then
-            gv("surviverun_rank", rank + 1)
+            property("surviverun_rank", rank + 1)
         end
         local exit_map = name2map("부여성")
         if exit_map then
@@ -65,8 +65,8 @@ function NPC_495(me, npc)
     end
 
     if map_id == MAP_ID_LOBBY then
-        local game_start = gv("survive_game_start")
-        local game_end = gv("survive_game_end")
+        local game_start = property("survive_game_start")
+        local game_end = property("survive_game_end")
         local now_ok = (game_start == nil and game_end == nil) or true
 
         if not me:has_items("서바이벌증표", 1) then
@@ -155,8 +155,8 @@ function NPC_495(me, npc)
         return
     end
 
-    local join_start = gv("survive_join_start")
-    local join_end = gv("survive_join_end")
+    local join_start = property("survive_join_start")
+    local join_end = property("survive_join_end")
     local in_join = (join_start == nil and join_end == nil) or true
 
     if not in_join then

--- a/server/game/scripts/npc/토로라비.lua
+++ b/server/game/scripts/npc/토로라비.lua
@@ -1,6 +1,6 @@
 
 function NPC_576(me, npc)
-    if gv("goldarcon") ~= 36 then
+    if property("goldarcon") ~= 36 then
         me:dialog(npc, "지금은 때가 아닙니다.", false, false)
         return
     end

--- a/server/game/scripts/schedule/schedule.lua
+++ b/server/game/scripts/schedule/schedule.lua
@@ -8,7 +8,7 @@ end
 
 -- Daily 18:00: restock batteries at 시계장인 (clock_time_item)
 function ON_SCHEDULE_2()
-    gv("clock_time_item", 10)
+    property("clock_time_item", 10)
 end
 
 function ON_SCHEDULE_3()

--- a/server/game/scripts/server.lua
+++ b/server/game/scripts/server.lua
@@ -769,7 +769,7 @@ function sky_maze_shuffle(seed)
     end
     shuffle_array(arr, 1, 25)
     for i = 0, 26 do
-        gv("sky_maze_" .. tostring(i), arr[i])
+        property("sky_maze_" .. tostring(i), arr[i])
     end
 end
 
@@ -781,12 +781,12 @@ function pk_sky_maze_shuffle(seed)
     end
     shuffle_array(arr, 1, 25)
     for i = 0, 26 do
-        gv("pk_sky_maze_" .. tostring(i), arr[i])
+        property("pk_sky_maze_" .. tostring(i), arr[i])
     end
 end
 
 function get_sky_maze_slot(i)
-    local map_id = gv("sky_maze_" .. tostring(i))
+    local map_id = property("sky_maze_" .. tostring(i))
     if map_id == nil then
         return SKY_MAZE_NAMES[i + 1]
     end
@@ -798,7 +798,7 @@ function get_sky_maze_slot(i)
 end
 
 function get_pk_sky_maze_slot(i)
-    local map_id = gv("pk_sky_maze_" .. tostring(i))
+    local map_id = property("pk_sky_maze_" .. tostring(i))
     if map_id == nil then
         return PK_SKY_MAZE_NAMES[i + 1]
     end
@@ -810,7 +810,7 @@ function get_pk_sky_maze_slot(i)
 end
 
 local function get_sky_maze_slot_id(i)
-    local map_id = gv("sky_maze_" .. tostring(i))
+    local map_id = property("sky_maze_" .. tostring(i))
     if map_id == nil then
         return map_name_to_id(SKY_MAZE_NAMES[i + 1])
     end
@@ -818,7 +818,7 @@ local function get_sky_maze_slot_id(i)
 end
 
 local function get_pk_sky_maze_slot_id(i)
-    local map_id = gv("pk_sky_maze_" .. tostring(i))
+    local map_id = property("pk_sky_maze_" .. tostring(i))
     if map_id == nil then
         return map_name_to_id(PK_SKY_MAZE_NAMES[i + 1])
     end
@@ -865,7 +865,7 @@ function ON_WARP_SKY_MAZE(me)
     local map_name = map:model():name()
     local x, y = me:position()
     
-    if gv("sky_maze_0") == nil then
+    if property("sky_maze_0") == nil then
         sky_maze_shuffle()
     end
     
@@ -946,7 +946,7 @@ function ON_WARP_PK_SKY_MAZE(me)
     local map_name = map:model():name()
     local x, y = me:position()
     
-    if gv("pk_sky_maze_0") == nil then
+    if property("pk_sky_maze_0") == nil then
         pk_sky_maze_shuffle()
     end
     

--- a/server/game/src/builtin/object.cpp
+++ b/server/game/src/builtin/object.cpp
@@ -2,6 +2,7 @@
 #include <fb/game/server.h>
 #include <fb/game/character.h>
 #include <fb/game/appearance.h>
+#include <async/propagation.h>
 
 using namespace fb::game;
 using table = fb::model::table;
@@ -578,9 +579,10 @@ int builtin::object::builtin_map(lua_State* L)
     }
     else
     {
-        auto weak    = obj->weak_from_this_as<fb::game::object>();
-        auto builder = server->threads.new_builder(weak);
-        builder.func = [=](auto& thread) -> async::task<void> {
+        auto weak       = obj->weak_from_this_as<fb::game::object>();
+        auto builder    = server->threads.new_builder(weak);
+        builder.context = fb::execution_context::token();
+        builder.func    = [=](auto& thread) -> async::task<void> {
             async::awaitable_then(static_func(weak, map, position), [=](auto result) {
                 auto success = result();
                 lua->ensure_resume(

--- a/server/game/src/builtin/server.cpp
+++ b/server/game/src/builtin/server.cpp
@@ -1257,7 +1257,7 @@ int builtin::server::builtin_drop_rate_multiplier(lua_State* L)
     }
 }
 
-int builtin::server::builtin_gv(lua_State* L)
+int builtin::server::builtin_property(lua_State* L)
 {
     auto lua = fb::lua::get(L);
     if (lua == nullptr)
@@ -1280,7 +1280,7 @@ int builtin::server::builtin_gv(lua_State* L)
         Json::Value value;
         bool        found = false;
         {
-            auto guard = server->vars.enter_read();
+            auto guard = server->property.enter_read();
             auto it    = guard.value().find(key);
             if (it != guard.value().end())
             {
@@ -1314,7 +1314,7 @@ int builtin::server::builtin_gv(lua_State* L)
             const char* s = lua_tostring(L, 2);
             Json::Value val(s ? s : "");
             {
-                auto guard         = server->vars.enter_write();
+                auto guard         = server->property.enter_write();
                 guard.value()[key] = val;
             }
         }
@@ -1322,7 +1322,7 @@ int builtin::server::builtin_gv(lua_State* L)
         {
             double n = lua_tonumber(L, 2);
             {
-                auto guard         = server->vars.enter_write();
+                auto guard         = server->property.enter_write();
                 guard.value()[key] = Json::Value(n);
             }
         }
@@ -1330,7 +1330,7 @@ int builtin::server::builtin_gv(lua_State* L)
         {
             bool b = lua_toboolean(L, 2) != 0;
             {
-                auto guard         = server->vars.enter_write();
+                auto guard         = server->property.enter_write();
                 guard.value()[key] = Json::Value(b);
             }
         }

--- a/server/game/src/handler/timer/schedule_timer.cpp
+++ b/server/game/src/handler/timer/schedule_timer.cpp
@@ -1,18 +1,13 @@
 #include <fb/game/handler/timer/schedule_timer.h>
-
 #include <fb/game/server.h>
 
 using namespace fb::game::handler::timer;
 
 schedule_timer::schedule_timer(fb::game::server& server) :
-
     fb::handler::timer<fb::game::server>(server)
-
 { }
 
 async::task<void> schedule_timer::handle()
-
 {
-
     co_await this->server.schedules.poll();
 }

--- a/server/game/src/server/server.cpp
+++ b/server/game/src/server/server.cpp
@@ -114,7 +114,7 @@ server::server(boost::asio::io_context& io_context, uint16_t port) :
     lua::build("regex", builtin::server::builtin_regex);
     lua::build("exp_multiplier", builtin::server::builtin_exp_multiplier);
     lua::build("drop_rate_multiplier", builtin::server::builtin_drop_rate_multiplier);
-    lua::build("gv", builtin::server::builtin_gv);
+    lua::build("property", builtin::server::builtin_property);
 
     for (auto& [_, root] : ist)
     {
@@ -265,7 +265,7 @@ async::task<void> server::on_start()
     this->handler.amqp.bind<fb::game::handler::amqp::start_maintenance>(
         std::format("fb.{}.game.{}", world, fb::config<uint32_t>("id")));
 
-    // Run server init script once (gv and other vars) on the least loaded thread
+    // Run server init script once (property and other startup state) on the least loaded thread
     auto* init_thread = this->threads.least_loaded();
     if (init_thread != nullptr)
     {

--- a/server/http/Repository/Cache/LocalHashMemoryCacheLayer.cs
+++ b/server/http/Repository/Cache/LocalHashMemoryCacheLayer.cs
@@ -1,0 +1,74 @@
+using Http.Model;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+
+namespace Http.Reepository.Cache
+{
+    /// <summary>
+    /// L1 in-process cache for Redis hash (multi-field) entities.
+    /// Scoped to the repository instance (one per HTTP request).
+    /// </summary>
+    public class LocalHashMemoryCacheLayer<TModel> where TModel : class, IModel
+    {
+        private readonly Dictionary<string, Dictionary<string, string>> _cache = new Dictionary<string, Dictionary<string, string>>();
+
+        private static string ToKey(RedisKey redisKey) => redisKey.ToString();
+
+        public TModel TryGetField(RedisKey redisKey, RedisValue field)
+        {
+            if (!_cache.TryGetValue(ToKey(redisKey), out var fields))
+                return null;
+
+            if (!fields.TryGetValue(field.ToString(), out var json))
+                return null;
+
+            var value = JsonConvert.DeserializeObject<TModel>(json);
+            if (value == null || value.Deleted)
+                return null;
+
+            return value;
+        }
+
+        public bool HasKey(RedisKey redisKey)
+        {
+            return _cache.ContainsKey(ToKey(redisKey));
+        }
+
+        public IEnumerable<TModel> GetAll(RedisKey redisKey)
+        {
+            if (!_cache.TryGetValue(ToKey(redisKey), out var fields))
+                return Enumerable.Empty<TModel>();
+
+            return fields.Values
+                .Select(x => JsonConvert.DeserializeObject<TModel>(x))
+                .Where(x => x != null && !x.Deleted);
+        }
+
+        public void PutAll(RedisKey redisKey, Dictionary<string, string> fields)
+        {
+            _cache[ToKey(redisKey)] = new Dictionary<string, string>(fields);
+        }
+
+        public void PutField(RedisKey redisKey, RedisValue field, string json)
+        {
+            var key = ToKey(redisKey);
+            if (!_cache.TryGetValue(key, out var fields))
+            {
+                fields = new Dictionary<string, string>();
+                _cache[key] = fields;
+            }
+
+            fields[field.ToString()] = json;
+        }
+
+        public void PutField(RedisKey redisKey, RedisValue field, TModel value)
+        {
+            PutField(redisKey, field, JsonConvert.SerializeObject(value));
+        }
+
+        public void Remove(RedisKey redisKey)
+        {
+            _cache.Remove(ToKey(redisKey));
+        }
+    }
+}

--- a/server/http/Repository/Cache/LocalValueMemoryCacheLayer.cs
+++ b/server/http/Repository/Cache/LocalValueMemoryCacheLayer.cs
@@ -1,0 +1,44 @@
+using Http.Model;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+
+namespace Http.Reepository.Cache
+{
+    /// <summary>
+    /// L1 in-process cache for Redis value (single-key) entities.
+    /// Scoped to the repository instance (one per HTTP request).
+    /// </summary>
+    public class LocalValueMemoryCacheLayer<TModel> where TModel : class, IModel
+    {
+        private readonly Dictionary<string, string> _cache = new Dictionary<string, string>();
+
+        private static string ToKey(RedisKey redisKey) => redisKey.ToString();
+
+        public TModel TryGet(RedisKey redisKey)
+        {
+            if (!_cache.TryGetValue(ToKey(redisKey), out var json))
+                return null;
+
+            var value = JsonConvert.DeserializeObject<TModel>(json);
+            if (value == null || value.Deleted)
+                return null;
+
+            return value;
+        }
+
+        public bool TryGetRaw(RedisKey redisKey, out string json)
+        {
+            return _cache.TryGetValue(ToKey(redisKey), out json);
+        }
+
+        public void Put(RedisKey redisKey, TModel value)
+        {
+            _cache[ToKey(redisKey)] = JsonConvert.SerializeObject(value);
+        }
+
+        public void PutRaw(RedisKey redisKey, string json)
+        {
+            _cache[ToKey(redisKey)] = json;
+        }
+    }
+}

--- a/server/http/Repository/Cache/RedisHashCacheLayer.cs
+++ b/server/http/Repository/Cache/RedisHashCacheLayer.cs
@@ -1,0 +1,252 @@
+using Http.Model;
+using Http.Redis;
+using Http.Service;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+
+namespace Http.Reepository.Cache
+{
+    /// <summary>
+    /// L2 Redis cache layer for hash (multi-field) entities.
+    /// </summary>
+    public class RedisHashCacheLayer<TModel> where TModel : class, IModel, IRedisHashKey
+    {
+        private static readonly string UpdateHashExpiryScript = """
+            local CACHE_KEY = KEYS[1]
+            local COUNT_REFS = KEYS[2]
+            local EXPIRY = tonumber(ARGV[1])
+            local LENGTH = tonumber(ARGV[2])
+
+            local offset = 2
+            for i = 1, LENGTH do
+                local field = ARGV[offset + i]
+                local value = ARGV[offset + i + 1]
+                redis.call('hset', CACHE_KEY, field, value)
+                offset = offset + 1
+            end
+
+            local contains_refs = redis.call('hexists', COUNT_REFS, CACHE_KEY)
+            if contains_refs == 0 then
+                redis.call('expire', CACHE_KEY, EXPIRY)
+            end
+
+            return {contains_refs}
+            """;
+
+        private static readonly string SetHashFieldScript = """
+            local CACHE_KEY = KEYS[1]
+            local COUNT_REFS = KEYS[2]
+            local FIELD = ARGV[1]
+            local VALUE = ARGV[2]
+
+            redis.call('hset', CACHE_KEY, FIELD, VALUE)
+            redis.call('persist', CACHE_KEY)
+            redis.call('hincrby', COUNT_REFS, CACHE_KEY, 1)
+
+            return 1
+            """;
+
+        private static readonly string SetHashFieldsScript = """
+            local CACHE_KEY = KEYS[1]
+            local COUNT_REFS = KEYS[2]
+            local LENGTH = tonumber(ARGV[1])
+
+            for i = 1, LENGTH do
+                local field = ARGV[i * 2]
+                local value = ARGV[i * 2 + 1]
+                redis.call('hset', CACHE_KEY, field, value)
+            end
+
+            redis.call('persist', CACHE_KEY)
+            redis.call('hincrby', COUNT_REFS, CACHE_KEY, 1)
+
+            return 1
+            """;
+
+        private static readonly string MultiHashGetScript = """
+            local n = #KEYS - 1
+            local cref = KEYS[n + 1]
+            local expiry = tonumber(ARGV[1])
+            local out = {}
+            for i = 1, n do
+                local k = KEYS[i]
+                local h = redis.call('HGETALL', k)
+                if h and #h > 0 then
+                    if redis.call('hexists', cref, k) == 0 then
+                        redis.call('EXPIRE', k, expiry)
+                    end
+                    table.insert(out, tostring(k))
+                    table.insert(out, tostring(#h / 2))
+                    for j = 1, #h do
+                        table.insert(out, h[j])
+                    end
+                else
+                    table.insert(out, tostring(k))
+                    table.insert(out, '0')
+                end
+            end
+            return out
+            """;
+
+        private readonly RedisService _redisService;
+        private readonly Dictionary<Service.Redis, LoadedLuaScript> _updateHashExpiryScripts = new Dictionary<Service.Redis, LoadedLuaScript>();
+        private readonly Dictionary<Service.Redis, LoadedLuaScript> _setHashFieldScripts = new Dictionary<Service.Redis, LoadedLuaScript>();
+        private readonly Dictionary<Service.Redis, LoadedLuaScript> _setHashFieldsScripts = new Dictionary<Service.Redis, LoadedLuaScript>();
+        private readonly Dictionary<Service.Redis, LoadedLuaScript> _multiHashGetScripts = new Dictionary<Service.Redis, LoadedLuaScript>();
+
+        public RedisHashCacheLayer(RedisService redisService)
+        {
+            _redisService = redisService;
+        }
+
+        public Service.Redis GetConnection(uint world, uint? hash)
+        {
+            return hash == null
+                ? _redisService.GetGlobalConnection(world)
+                : _redisService.GetShardConnection(world, hash.Value);
+        }
+
+        public async Task<IReadOnlyDictionary<RedisValue, TModel>> TryGetAllAsync(Service.Redis redis, RedisKey redisKey)
+        {
+            if (redis == null)
+                return new Dictionary<RedisValue, TModel>();
+
+            return await redis.Connection.JsonHashGetAllAsync<TModel>(redisKey);
+        }
+
+        public async Task<IReadOnlyDictionary<RedisValue, TModel>> TryGetFieldsAsync(Service.Redis redis, RedisKey redisKey)
+        {
+            if (redis == null)
+                return new Dictionary<RedisValue, TModel>();
+
+            return await redis.Connection.JsonHashGetAsync<TModel>(redisKey);
+        }
+
+        public async Task<bool> KeyExistsAsync(Service.Redis redis, RedisKey redisKey)
+        {
+            if (redis == null)
+                return false;
+
+            return await redis.Connection.KeyExistsAsync(redisKey);
+        }
+
+        public async Task WriteBackAsync(Service.Redis redis, RedisKey cacheKey, IEnumerable<TModel> values)
+        {
+            if (redis == null)
+                return;
+
+            var dataGroup = values.ToDictionary(x => x.GetRedisField(), x => x);
+            if (dataGroup.Count == 0)
+                return;
+
+            var scriptValues = new List<RedisValue>
+            {
+                (int)Const.CacheTimeToLive.TotalSeconds,
+                dataGroup.Count
+            };
+            foreach (var (field, entity) in dataGroup)
+            {
+                scriptValues.Add(field);
+                scriptValues.Add(JsonConvert.SerializeObject(entity));
+            }
+
+            if (!_updateHashExpiryScripts.TryGetValue(redis, out var script))
+            {
+                script = LuaScript.Prepare(UpdateHashExpiryScript).Load(redis.GetServer());
+                _updateHashExpiryScripts[redis] = script;
+            }
+
+            await redis.Connection.ScriptEvaluateAsync(script.Hash,
+                keys: [cacheKey, new RedisKey(Const.ReferenceCountKey)],
+                values: scriptValues.ToArray());
+        }
+
+        public async Task SetFieldAsync(Service.Redis redis, RedisKey cacheKey, RedisValue field, TModel value)
+        {
+            if (redis == null)
+                return;
+
+            if (!_setHashFieldScripts.TryGetValue(redis, out var script))
+            {
+                script = LuaScript.Prepare(SetHashFieldScript).Load(redis.GetServer());
+                _setHashFieldScripts[redis] = script;
+            }
+
+            await redis.Connection.ScriptEvaluateAsync(script.Hash,
+                keys: [cacheKey, new RedisKey(Const.ReferenceCountKey)],
+                values: [field, JsonConvert.SerializeObject(value)]);
+        }
+
+        public async Task SetFieldsAsync(Service.Redis redis, RedisKey cacheKey, IReadOnlyDictionary<RedisValue, TModel> values)
+        {
+            if (redis == null || values.Count == 0)
+                return;
+
+            if (!_setHashFieldsScripts.TryGetValue(redis, out var script))
+            {
+                script = LuaScript.Prepare(SetHashFieldsScript).Load(redis.GetServer());
+                _setHashFieldsScripts[redis] = script;
+            }
+
+            var scriptValues = new List<RedisValue> { values.Count };
+            foreach (var (field, val) in values)
+            {
+                scriptValues.Add(field);
+                scriptValues.Add(JsonConvert.SerializeObject(val));
+            }
+
+            await redis.Connection.ScriptEvaluateAsync(script.Hash,
+                keys: [cacheKey, new RedisKey(Const.ReferenceCountKey)],
+                values: scriptValues.ToArray());
+        }
+
+        public async Task<IReadOnlyList<(RedisKey RedisKey, Dictionary<string, string> Fields)>> TryGetManyAsync(
+            Service.Redis redis,
+            IReadOnlyList<RedisKey> redisKeys)
+        {
+            var result = new List<(RedisKey, Dictionary<string, string>)>();
+            if (redis == null || redisKeys.Count == 0)
+                return result;
+
+            var keys = new RedisKey[redisKeys.Count + 1];
+            for (var i = 0; i < redisKeys.Count; i++)
+            {
+                keys[i] = redisKeys[i];
+            }
+            keys[redisKeys.Count] = Const.ReferenceCountKey;
+            var values = new RedisValue[] { (int)Const.CacheTimeToLive.TotalSeconds };
+
+            if (!_multiHashGetScripts.TryGetValue(redis, out var multiHashScript))
+            {
+                multiHashScript = LuaScript.Prepare(MultiHashGetScript).Load(redis.GetServer());
+                _multiHashGetScripts[redis] = multiHashScript;
+            }
+
+            var multiResult = await redis.Connection.ScriptEvaluateAsync(multiHashScript.Hash, keys, values);
+            var flat = (RedisResult[])multiResult;
+            var idx = 0;
+            for (var i = 0; i < redisKeys.Count; i++)
+            {
+                if (idx >= flat.Length)
+                    break;
+
+                idx++;
+                var count = int.Parse(flat[idx++].ToString());
+                if (count == 0)
+                    continue;
+
+                var localCache = new Dictionary<string, string>();
+                for (var c = 0; c < count; c++)
+                {
+                    var field = flat[idx++].ToString();
+                    var valStr = flat[idx++].ToString();
+                    localCache[field] = valStr;
+                }
+
+                result.Add((redisKeys[i], localCache));
+            }
+
+            return result;
+        }
+    }
+}

--- a/server/http/Repository/Cache/RedisValueCacheLayer.cs
+++ b/server/http/Repository/Cache/RedisValueCacheLayer.cs
@@ -1,0 +1,146 @@
+using Http.Model;
+using Http.Redis;
+using Http.Service;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+
+namespace Http.Reepository.Cache
+{
+    /// <summary>
+    /// L2 Redis cache layer for single-key (value) entities.
+    /// </summary>
+    public class RedisValueCacheLayer<TModel> where TModel : class, IModel
+    {
+        private static readonly string UpdateValueExpiryScript = """
+            redis.call('set', @key, @value)
+
+            local contains_refs = redis.call('hexists', @cref, @key)
+            if contains_refs == 0 then
+                redis.call('expire', @key, @expiry)
+            end
+
+            return contains_refs
+            """;
+
+        private static readonly string MultiValueGetScript = """
+            local n = #KEYS - 1
+            local cref = KEYS[n + 1]
+            local expiry = tonumber(ARGV[1])
+            local results = {}
+            for i = 1, n do
+                local k = KEYS[i]
+                local v = redis.call('GET', k)
+                if v and v ~= '' then
+                    if redis.call('hexists', cref, k) == 0 then
+                        redis.call('EXPIRE', k, expiry)
+                    end
+                    table.insert(results, v)
+                else
+                    table.insert(results, false)
+                end
+            end
+            return results
+            """;
+
+        private readonly RedisService _redisService;
+        private readonly Dictionary<Service.Redis, LoadedLuaScript> _updateValueExpiryScripts = new Dictionary<Service.Redis, LoadedLuaScript>();
+        private readonly Dictionary<Service.Redis, LoadedLuaScript> _multiValueGetScripts = new Dictionary<Service.Redis, LoadedLuaScript>();
+
+        public RedisValueCacheLayer(RedisService redisService)
+        {
+            _redisService = redisService;
+        }
+
+        public Service.Redis GetConnection(uint world, uint? hash)
+        {
+            return hash == null
+                ? _redisService.GetGlobalConnection(world)
+                : _redisService.GetShardConnection(world, hash.Value);
+        }
+
+        public async Task<TModel> TryGetAsync(Service.Redis redis, RedisKey redisKey)
+        {
+            if (redis == null)
+                return null;
+
+            var value = await redis.Connection.JsonGetAsync<TModel>(redisKey);
+            if (value == null || value.Deleted)
+                return null;
+
+            return value;
+        }
+
+        public async Task WriteBackAsync(Service.Redis redis, RedisKey redisKey, TModel value)
+        {
+            if (redis == null)
+                return;
+
+            if (!_updateValueExpiryScripts.TryGetValue(redis, out var script))
+            {
+                script = LuaScript.Prepare(UpdateValueExpiryScript).Load(redis.GetServer());
+                _updateValueExpiryScripts[redis] = script;
+            }
+
+            await redis.Connection.ScriptEvaluateAsync(script, new
+            {
+                key = redisKey,
+                value = JsonConvert.SerializeObject(value),
+                cref = new RedisKey(Const.ReferenceCountKey),
+                expiry = (int)Const.CacheTimeToLive.TotalSeconds
+            });
+        }
+
+        public async Task SetAsync(Service.Redis redis, RedisKey redisKey, TModel value)
+        {
+            if (redis == null)
+                return;
+
+            await redis.Connection.TransactAsync(cmd =>
+            {
+                cmd.Enqueue(trans => trans.JsonSetAsync(redisKey, value));
+                cmd.Enqueue(trans => trans.KeyExpireAsync(redisKey, expiry: (TimeSpan?)null));
+                cmd.Enqueue(trans => trans.HashIncrementAsync(Const.ReferenceCountKey, redisKey.ToString()));
+            });
+        }
+
+        public async Task<IReadOnlyList<(RedisKey RedisKey, string Json)>> TryGetManyAsync(
+            Service.Redis redis,
+            IReadOnlyList<RedisKey> redisKeys)
+        {
+            var result = new List<(RedisKey, string)>();
+            if (redis == null || redisKeys.Count == 0)
+                return result;
+
+            var keys = new RedisKey[redisKeys.Count + 1];
+            for (var i = 0; i < redisKeys.Count; i++)
+            {
+                keys[i] = redisKeys[i];
+            }
+            keys[redisKeys.Count] = Const.ReferenceCountKey;
+            var values = new RedisValue[] { (int)Const.CacheTimeToLive.TotalSeconds };
+
+            if (!_multiValueGetScripts.TryGetValue(redis, out var multiGetScript))
+            {
+                multiGetScript = LuaScript.Prepare(MultiValueGetScript).Load(redis.GetServer());
+                _multiValueGetScripts[redis] = multiGetScript;
+            }
+
+            var multiResult = await redis.Connection.ScriptEvaluateAsync(multiGetScript.Hash, keys, values);
+            var elements = (RedisResult[])multiResult;
+            for (var i = 0; i < redisKeys.Count; i++)
+            {
+                var elem = elements[i];
+                if (elem.IsNull)
+                    continue;
+
+                var jsonStr = elem.ToString();
+                if (string.IsNullOrEmpty(jsonStr))
+                    continue;
+
+                result.Add((redisKeys[i], jsonStr));
+            }
+
+            return result;
+        }
+    }
+}

--- a/server/http/Repository/Repository.RedisHash.cs
+++ b/server/http/Repository/Repository.RedisHash.cs
@@ -1,106 +1,15 @@
 using Http.Model;
-using Http.Redis;
+using Http.Reepository.Cache;
 using Http.Service;
 using Newtonsoft.Json;
 using StackExchange.Redis;
-using System.Collections.Concurrent;
 
 namespace Http.Reepository
 {
     public abstract class RedisHashRepository<TModel, TKey> : Repository<TModel, TKey> where TModel : class, IModel, TKey where TKey : IRedisHashKey
     {
-        private static readonly string UpdateHashExpiryScript = """
-            local CACHE_KEY = KEYS[1]
-            local COUNT_REFS = KEYS[2]
-            local EXPIRY = tonumber(ARGV[1])
-            local LENGTH = tonumber(ARGV[2])
-
-            local offset = 2
-            for i = 1, LENGTH do
-                local field = ARGV[offset + i]
-                local value = ARGV[offset + i + 1]
-                redis.call('hset', CACHE_KEY, field, value)
-                offset = offset + 1
-            end
-
-            local contains_refs = redis.call('hexists', COUNT_REFS, CACHE_KEY)
-            if contains_refs == 0 then
-                redis.call('expire', CACHE_KEY, EXPIRY)
-            end
-
-            return {contains_refs}
-            """;
-
-        private static readonly string SetHashFieldScript = """
-            local CACHE_KEY = KEYS[1]
-            local COUNT_REFS = KEYS[2]
-            local FIELD = ARGV[1]
-            local VALUE = ARGV[2]
-
-            -- Set hash field
-            redis.call('hset', CACHE_KEY, FIELD, VALUE)
-
-            -- Remove expiry (persist the key)
-            redis.call('persist', CACHE_KEY)
-
-            -- Increment reference count
-            redis.call('hincrby', COUNT_REFS, CACHE_KEY, 1)
-
-            return 1
-            """;
-
-        private static readonly string SetHashFieldsScript = """
-            local CACHE_KEY = KEYS[1]
-            local COUNT_REFS = KEYS[2]
-            local LENGTH = tonumber(ARGV[1])
-
-            -- Set hash fields
-            for i = 1, LENGTH do
-                local field = ARGV[i * 2]
-                local value = ARGV[i * 2 + 1]
-                redis.call('hset', CACHE_KEY, field, value)
-            end
-
-            -- Remove expiry (persist the key)
-            redis.call('persist', CACHE_KEY)
-
-            -- Increment reference count
-            redis.call('hincrby', COUNT_REFS, CACHE_KEY, 1)
-
-            return 1
-            """;
-
-        private static readonly string MultiHashGetScript = """
-            local n = #KEYS - 1
-            local cref = KEYS[n + 1]
-            local expiry = tonumber(ARGV[1])
-            local out = {}
-            for i = 1, n do
-                local k = KEYS[i]
-                local h = redis.call('HGETALL', k)
-                if h and #h > 0 then
-                    if redis.call('hexists', cref, k) == 0 then
-                        redis.call('EXPIRE', k, expiry)
-                    end
-                    table.insert(out, tostring(k))
-                    table.insert(out, tostring(#h / 2))
-                    for j = 1, #h do
-                        table.insert(out, h[j])
-                    end
-                else
-                    table.insert(out, tostring(k))
-                    table.insert(out, '0')
-                end
-            end
-            return out
-            """;
-
-        private readonly ConcurrentDictionary<string, ConcurrentDictionary<string, string>> _local = new ConcurrentDictionary<string, ConcurrentDictionary<string, string>>();
-        private readonly Dictionary<Service.Redis, LoadedLuaScript> _updateHashExpiryScripts = new Dictionary<Service.Redis, LoadedLuaScript>();
-        private readonly Dictionary<Service.Redis, LoadedLuaScript> _setHashFieldScripts = new Dictionary<Service.Redis, LoadedLuaScript>();
-        private readonly Dictionary<Service.Redis, LoadedLuaScript> _setHashFieldsScripts = new Dictionary<Service.Redis, LoadedLuaScript>();
-        private readonly Dictionary<Service.Redis, LoadedLuaScript> _multiHashGetScripts = new Dictionary<Service.Redis, LoadedLuaScript>();
-        private readonly RedisService _redisService;
+        private readonly LocalHashMemoryCacheLayer<TModel> _local;
+        private readonly RedisHashCacheLayer<TModel> _redis;
         private readonly RedisDistributedLockService _distributedLock;
         private readonly WriteBackService _dbExecuteService;
 
@@ -109,63 +18,26 @@ namespace Http.Reepository
             RedisDistributedLockService distributedLock,
             WriteBackService dbExecuteService) : base(dbContext)
         {
-            _redisService = redisService;
+            _local = new LocalHashMemoryCacheLayer<TModel>();
+            _redis = new RedisHashCacheLayer<TModel>(redisService);
             _distributedLock = distributedLock;
             _dbExecuteService = dbExecuteService;
         }
 
-        private static string GetLocalCacheKey(TKey key)
-        {
-            return $"{key.GetRedisKey()}:{key.GetRedisField()}";
-        }
+        private static string GetLockKey(TKey key) => GetLockKey(key.GetRedisKey());
 
-        private static string GetLockKey(TKey key)
-        {
-            return GetLockKey(key.GetRedisKey());
-        }
-
-        private static string GetLockKey(RedisKey key)
-        {
-            return $"fb:lock:{key}";
-        }
+        private static string GetLockKey(RedisKey key) => $"fb:lock:{key}";
 
         private async Task<IEnumerable<TModel>> SyncCacheFromDatabase(uint world, Service.Redis redis, TKey key)
         {
-            var mysqlValues = await base.GetAll(world, key);
-            if (mysqlValues.Any())
+            var mysqlValues = (await base.GetAll(world, key)).ToList();
+            if (mysqlValues.Count == 0)
+                return mysqlValues;
+
+            foreach (var g in mysqlValues.GroupBy(x => x.GetRedisKey()))
             {
-                foreach (var g in mysqlValues.GroupBy(x => x.GetRedisKey()))
-                {
-                    var dataGroup = g.ToDictionary(x => x.GetRedisField(), x => x);
-                    var values = new List<RedisValue>
-                        {
-                            (int)Const.CacheTimeToLive.TotalSeconds,
-                            dataGroup.Count
-                        };
-                    foreach (var (k, v) in dataGroup)
-                    {
-                        values.Add(k);
-                        values.Add(JsonConvert.SerializeObject(v));
-                    }
-
-                    if (!_updateHashExpiryScripts.TryGetValue(redis, out var script))
-                    {
-                        script = LuaScript.Prepare(UpdateHashExpiryScript).Load(redis.GetServer());
-                        _updateHashExpiryScripts[redis] = script;
-                    }
-
-                    var result = await redis.Connection.ScriptEvaluateAsync(script.Hash,
-                        keys:
-                        [
-                            g.Key,
-                                new RedisKey(Const.ReferenceCountKey)
-                        ],
-                        values: values.ToArray());
-
-                    _local.AddOrUpdate(g.Key,
-                        new ConcurrentDictionary<string, string>(g.ToDictionary(x => x.GetRedisField().ToString(), x => JsonConvert.SerializeObject(x))),
-                        (key, oldValue) => new ConcurrentDictionary<string, string>(g.ToDictionary(x => x.GetRedisField().ToString(), x => JsonConvert.SerializeObject(x))));
-                }
+                await _redis.WriteBackAsync(redis, g.Key, g);
+                _local.PutAll(g.Key, g.ToDictionary(x => x.GetRedisField().ToString(), x => JsonConvert.SerializeObject(x)));
             }
 
             return mysqlValues;
@@ -175,25 +47,15 @@ namespace Http.Reepository
         {
             await using var _ = await _distributedLock.Lock(world, GetLockKey(key));
 
-            if (_local.TryGetValue(key.GetRedisKey(), out var localValues) && localValues.TryGetValue(key.GetRedisField(), out var localValue))
-            {
-                var value = JsonConvert.DeserializeObject<TModel>(localValue);
-                if (value.Deleted)
-                    return null;
+            var localValue = _local.TryGetField(key.GetRedisKey(), key.GetRedisField());
+            if (localValue != null)
+                return localValue;
 
-                return value;
-            }
-
-            var hash = key.GetHash();
-            var redis = hash == null ? _redisService.GetGlobalConnection(world) : _redisService.GetShardConnection(world, hash.Value);
-            if (redis == null)
-                return null;
-
-            var redisValues = await redis.Connection.JsonHashGetAllAsync<TModel>(key.GetRedisKey());
+            var redis = _redis.GetConnection(world, key.GetHash());
+            var redisValues = await _redis.TryGetAllAsync(redis, key.GetRedisKey());
             if (redisValues.Count > 0)
             {
-                var newCache = new ConcurrentDictionary<string, string>(redisValues.ToDictionary(x => x.Key.ToString(), x => JsonConvert.SerializeObject(x.Value)));
-                _local.AddOrUpdate(key.GetRedisKey(), newCache, (k, oldValue) => newCache);
+                _local.PutAll(key.GetRedisKey(), redisValues.ToDictionary(x => x.Key.ToString(), x => JsonConvert.SerializeObject(x.Value)));
                 if (redisValues.TryGetValue(key.GetRedisField(), out var redisValue))
                 {
                     if (redisValue.Deleted)
@@ -205,20 +67,9 @@ namespace Http.Reepository
 
             var mysqlValues = await SyncCacheFromDatabase(world, redis, key);
             var found = mysqlValues.FirstOrDefault(x =>
-            {
-                if (x.GetRedisKey() != key.GetRedisKey())
-                    return false;
+                x.GetRedisKey() == key.GetRedisKey() && x.GetRedisField() == key.GetRedisField());
 
-                if (x.GetRedisField() != key.GetRedisField())
-                    return false;
-
-                return true;
-            });
-
-            if (found == null)
-                return null;
-
-            if (found.Deleted)
+            if (found == null || found.Deleted)
                 return null;
 
             return found;
@@ -228,19 +79,14 @@ namespace Http.Reepository
         {
             await using var _ = await _distributedLock.Lock(world, GetLockKey(key));
 
-            if (_local.TryGetValue(key.GetRedisKey(), out var localValues))
-                return localValues.Values.Select(x => JsonConvert.DeserializeObject<TModel>(x)).Where(x => !x.Deleted);
+            if (_local.HasKey(key.GetRedisKey()))
+                return _local.GetAll(key.GetRedisKey());
 
-            var hash = key.GetHash();
-            var redis = hash == null ? _redisService.GetGlobalConnection(world) : _redisService.GetShardConnection(world, hash.Value);
-            if (redis == null)
-                return Enumerable.Empty<TModel>();
-
-            var redisValues = await redis.Connection.JsonHashGetAsync<TModel>(key.GetRedisKey());
+            var redis = _redis.GetConnection(world, key.GetHash());
+            var redisValues = await _redis.TryGetFieldsAsync(redis, key.GetRedisKey());
             if (redisValues.Count > 0)
             {
-                var newCache = new ConcurrentDictionary<string, string>(redisValues.ToDictionary(x => x.Key.ToString(), x => JsonConvert.SerializeObject(x.Value)));
-                _local.AddOrUpdate(key.GetRedisKey(), newCache, (k, oldValue) => newCache);
+                _local.PutAll(key.GetRedisKey(), redisValues.ToDictionary(x => x.Key.ToString(), x => JsonConvert.SerializeObject(x.Value)));
                 return redisValues.Values.Where(x => !x.Deleted);
             }
 
@@ -258,8 +104,7 @@ namespace Http.Reepository
 
             foreach (var group in keys.Distinct().GroupBy(k => k.GetHash()))
             {
-                var hash = group.Key;
-                var redis = hash == null ? _redisService.GetGlobalConnection(world) : _redisService.GetShardConnection(world, hash.Value);
+                var redis = _redis.GetConnection(world, group.Key);
                 if (redis == null)
                 {
                     missingKeys.AddRange(group);
@@ -270,14 +115,9 @@ namespace Http.Reepository
                 var localMiss = new List<TKey>();
                 foreach (var key in keyList)
                 {
-                    var redisKey = key.GetRedisKey();
-                    if (_local.TryGetValue(redisKey, out var fields))
+                    if (_local.HasKey(key.GetRedisKey()))
                     {
-                        var list = fields.Values.Select(x => JsonConvert.DeserializeObject<TModel>(x)).Where(x => x != null && !x.Deleted).ToList();
-                        foreach (var m in list)
-                        {
-                            result.Add(m);
-                        }
+                        result.AddRange(_local.GetAll(key.GetRedisKey()));
                     }
                     else
                     {
@@ -287,53 +127,25 @@ namespace Http.Reepository
 
                 if (localMiss.Count > 0)
                 {
-                    var redisKeys = new RedisKey[localMiss.Count + 1];
-                    for (var i = 0; i < localMiss.Count; i++)
-                    {
-                        redisKeys[i] = localMiss[i].GetRedisKey();
-                    }
-                    redisKeys[localMiss.Count] = Const.ReferenceCountKey;
-                    var values = new RedisValue[] { (int)Const.CacheTimeToLive.TotalSeconds };
+                    var redisKeys = localMiss.Select(k => k.GetRedisKey()).ToList();
+                    var redisHits = await _redis.TryGetManyAsync(redis, redisKeys);
+                    var hitKeys = new HashSet<string>(redisHits.Select(x => x.RedisKey.ToString()));
 
-                    if (!_multiHashGetScripts.TryGetValue(redis, out var multiHashScript))
+                    foreach (var (redisKey, fields) in redisHits)
                     {
-                        multiHashScript = LuaScript.Prepare(MultiHashGetScript).Load(redis.GetServer());
-                        _multiHashGetScripts[redis] = multiHashScript;
+                        _local.PutAll(redisKey, fields);
+                        foreach (var json in fields.Values)
+                        {
+                            var model = JsonConvert.DeserializeObject<TModel>(json);
+                            if (model != null && !model.Deleted)
+                                result.Add(model);
+                        }
                     }
 
-                    var multiResult = await redis.Connection.ScriptEvaluateAsync(multiHashScript.Hash, redisKeys, values);
-                    var flat = (RedisResult[])multiResult;
-                    var idx = 0;
                     foreach (var key in localMiss)
                     {
-                        if (idx >= flat.Length) break;
-                        var keyStr = flat[idx++].ToString();
-                        var count = int.Parse(flat[idx++].ToString());
-                        if (count == 0)
-                        {
+                        if (!hitKeys.Contains(key.GetRedisKey().ToString()))
                             missingKeys.Add(key);
-                            continue;
-                        }
-                        var hashDict = new Dictionary<RedisValue, string>();
-                        for (var c = 0; c < count; c++)
-                        {
-                            var field = flat[idx++].ToString();
-                            var valStr = flat[idx++].ToString();
-                            hashDict[(RedisValue)field] = valStr;
-                        }
-                        var list = new List<TModel>();
-                        var localCache = new ConcurrentDictionary<string, string>();
-                        foreach (var kv in hashDict)
-                        {
-                            var model = JsonConvert.DeserializeObject<TModel>(kv.Value);
-                            if (model != null && !model.Deleted)
-                            {
-                                list.Add(model);
-                                result.Add(model);
-                            }
-                            localCache[kv.Key.ToString()] = kv.Value;
-                        }
-                        _local.AddOrUpdate(key.GetRedisKey().ToString(), localCache, (k, old) => localCache);
                     }
                 }
             }
@@ -349,40 +161,17 @@ namespace Http.Reepository
                     {
                         result.Add(entity);
                     }
+
                     if (list.Count == 0)
                         continue;
 
                     await using var _ = await _distributedLock.Lock(world, GetLockKey(key));
 
-                    var hash = key.GetHash();
-                    var redisForKey = hash == null ? _redisService.GetGlobalConnection(world) : _redisService.GetShardConnection(world, hash.Value);
-                    if (redisForKey != null)
+                    var redis = _redis.GetConnection(world, key.GetHash());
+                    if (redis != null)
                     {
-                        var dataGroup = list.ToDictionary(x => x.GetRedisField(), x => x);
-                        var values = new List<RedisValue>
-                        {
-                            (int)Const.CacheTimeToLive.TotalSeconds,
-                            dataGroup.Count
-                        };
-                        foreach (var (k, v) in dataGroup)
-                        {
-                            values.Add(k);
-                            values.Add(JsonConvert.SerializeObject(v));
-                        }
-
-                        if (!_updateHashExpiryScripts.TryGetValue(redisForKey, out var script))
-                        {
-                            script = LuaScript.Prepare(UpdateHashExpiryScript).Load(redisForKey.GetServer());
-                            _updateHashExpiryScripts[redisForKey] = script;
-                        }
-
-                        await redisForKey.Connection.ScriptEvaluateAsync(script.Hash,
-                            keys: [key.GetRedisKey(), new RedisKey(Const.ReferenceCountKey)],
-                            values: values.ToArray());
-
-                        _local.AddOrUpdate(key.GetRedisKey(),
-                            new ConcurrentDictionary<string, string>(dataGroup.ToDictionary(x => x.Key.ToString(), x => JsonConvert.SerializeObject(x.Value))),
-                            (k, old) => new ConcurrentDictionary<string, string>(dataGroup.ToDictionary(x => x.Key.ToString(), x => JsonConvert.SerializeObject(x.Value))));
+                        await _redis.WriteBackAsync(redis, key.GetRedisKey(), list);
+                        _local.PutAll(key.GetRedisKey(), list.ToDictionary(x => x.GetRedisField().ToString(), x => JsonConvert.SerializeObject(x)));
                     }
                 }
             }
@@ -397,45 +186,20 @@ namespace Http.Reepository
                 value.UpdatedDate = DateTime.Now;
 
                 var redisKey = value.GetRedisKey();
-                var hash = value.GetHash();
-                var redis = hash == null ? _redisService.GetGlobalConnection(world) : _redisService.GetShardConnection(world, hash.Value);
+                var redis = _redis.GetConnection(world, value.GetHash());
                 if (redis == null)
                     return;
 
-                // Use distributed lock to ensure cache synchronization
                 await using (await _distributedLock.Lock(world, GetLockKey(value)))
                 {
-                    // Check if Redis key exists
-                    var keyExists = await redis.Connection.KeyExistsAsync(redisKey);
-                    if (!keyExists)
+                    if (!await _redis.KeyExistsAsync(redis, redisKey))
                     {
-                        // Redis key doesn't exist, clear local cache and call SyncCacheFromDatabase to synchronize cache with database
-                        _local.TryRemove(redisKey, out _);
+                        _local.Remove(redisKey);
                         await SyncCacheFromDatabase(world, redis, value);
                     }
 
-                    // Add the new entity to Redis cache using Lua script
-                    if (!_setHashFieldScripts.TryGetValue(redis, out var script))
-                    {
-                        script = LuaScript.Prepare(SetHashFieldScript).Load(redis.GetServer());
-                        _setHashFieldScripts[redis] = script;
-                    }
-
-                    await redis.Connection.ScriptEvaluateAsync(script.Hash,
-                        keys:
-                        [
-                            redisKey,
-                            new RedisKey(Const.ReferenceCountKey)
-                        ],
-                        values:
-                        [
-                            value.GetRedisField(),
-                            JsonConvert.SerializeObject(value)
-                        ]);
-
-                    // Update local cache (thread-safe with ConcurrentDictionary)
-                    var localValues = _local.GetOrAdd(redisKey, _ => new ConcurrentDictionary<string, string>());
-                    localValues[value.GetRedisField()] = JsonConvert.SerializeObject(value);
+                    await _redis.SetFieldAsync(redis, redisKey, value.GetRedisField(), value);
+                    _local.PutField(redisKey, value.GetRedisField(), value);
                 }
 
                 var sql = OnUpsert(value);
@@ -456,65 +220,32 @@ namespace Http.Reepository
 
                 foreach (var hashGroup in values.GroupBy(x => x.GetHash()))
                 {
-                    var hash = hashGroup.Key;
-                    var redis = hash == null ? _redisService.GetGlobalConnection(world) : _redisService.GetShardConnection(world, hash.Value);
+                    var redis = _redis.GetConnection(world, hashGroup.Key);
                     if (redis == null)
                         continue;
 
-                    // Process keyGroups sequentially
                     foreach (var keyGroup in hashGroup.GroupBy(x => x.GetRedisKey()))
                     {
                         var redisKey = keyGroup.Key;
                         var valueSet = keyGroup.ToDictionary(x => x.GetRedisField(), x => x);
 
-                        // Use distributed lock to ensure cache synchronization
                         await using (await _distributedLock.Lock(world, GetLockKey(redisKey)))
                         {
-                            // Check if Redis key exists
-                            var keyExists = await redis.Connection.KeyExistsAsync(redisKey);
-                            if (!keyExists)
+                            if (!await _redis.KeyExistsAsync(redis, redisKey))
                             {
-                                // Redis key doesn't exist, clear local cache and call SyncCacheFromDatabase to synchronize cache with database
-                                _local.TryRemove(redisKey, out _);
+                                _local.Remove(redisKey);
                                 await SyncCacheFromDatabase(world, redis, keyGroup.First());
                             }
 
-                            // Add the new entities to Redis cache using Lua script
-                            if (!_setHashFieldsScripts.TryGetValue(redis, out var script))
-                            {
-                                script = LuaScript.Prepare(SetHashFieldsScript).Load(redis.GetServer());
-                                _setHashFieldsScripts[redis] = script;
-                            }
-
-                            var scriptValues = new List<RedisValue>
-                            {
-                                valueSet.Count
-                            };
+                            await _redis.SetFieldsAsync(redis, redisKey, valueSet);
                             foreach (var (field, val) in valueSet)
                             {
-                                scriptValues.Add(field);
-                                scriptValues.Add(JsonConvert.SerializeObject(val));
-                            }
-
-                            await redis.Connection.ScriptEvaluateAsync(script.Hash,
-                                keys:
-                                [
-                                    redisKey,
-                                    new RedisKey(Const.ReferenceCountKey)
-                                ],
-                                values: scriptValues.ToArray());
-
-                            // Update local cache (thread-safe with ConcurrentDictionary)
-                            var localValues = _local.GetOrAdd(redisKey, _ => new ConcurrentDictionary<string, string>());
-                            foreach (var (field, val) in valueSet)
-                            {
-                                localValues[field] = JsonConvert.SerializeObject(val);
+                                _local.PutField(redisKey, field, val);
                             }
                         }
 
-                        // Execute OnUpsert and Post for each keyGroup (same hash connection, but grouped by redisKey)
                         var sql = OnUpsert(keyGroup.ToArray());
-                        await _dbExecuteService.Post(world, hash, sql, redisKey.ToString());
+                        await _dbExecuteService.Post(world, hashGroup.Key, sql, redisKey.ToString());
                     }
                 }
             });

--- a/server/http/Repository/Repository.RedisValue.cs
+++ b/server/http/Repository/Repository.RedisValue.cs
@@ -1,5 +1,5 @@
 using Http.Model;
-using Http.Redis;
+using Http.Reepository.Cache;
 using Http.Service;
 using Newtonsoft.Json;
 using StackExchange.Redis;
@@ -8,41 +8,8 @@ namespace Http.Reepository
 {
     public abstract class RedisValueRepository<TModel, TKey> : Repository<TModel, TKey> where TModel : class, IModel, TKey where TKey : IRedisValueKey
     {
-        private static readonly string UpdateValueExpiryScript = """
-            redis.call('set', @key, @value)
-
-            local contains_refs = redis.call('hexists', @cref, @key)
-            if contains_refs == 0 then
-                redis.call('expire', @key, @expiry)
-            end
-
-            return contains_refs
-            """;
-
-        private static readonly string MultiValueGetScript = """
-            local n = #KEYS - 1
-            local cref = KEYS[n + 1]
-            local expiry = tonumber(ARGV[1])
-            local results = {}
-            for i = 1, n do
-                local k = KEYS[i]
-                local v = redis.call('GET', k)
-                if v and v ~= '' then
-                    if redis.call('hexists', cref, k) == 0 then
-                        redis.call('EXPIRE', k, expiry)
-                    end
-                    table.insert(results, v)
-                else
-                    table.insert(results, false)
-                end
-            end
-            return results
-            """;
-
-        private readonly Dictionary<string, string> _local = new Dictionary<string, string>();
-        private readonly Dictionary<Service.Redis, LoadedLuaScript> _updateValueExpiryScripts = new Dictionary<Service.Redis, LoadedLuaScript>();
-        private readonly Dictionary<Service.Redis, LoadedLuaScript> _multiValueGetScripts = new Dictionary<Service.Redis, LoadedLuaScript>();
-        private readonly RedisService _redisService;
+        private readonly LocalValueMemoryCacheLayer<TModel> _local;
+        private readonly RedisValueCacheLayer<TModel> _redis;
         private readonly RedisDistributedLockService _distributedLock;
         private readonly WriteBackService _dbExecuteService;
 
@@ -51,67 +18,36 @@ namespace Http.Reepository
             RedisDistributedLockService distributedLock,
             WriteBackService dbExecuteService) : base(dbContext)
         {
-            _redisService = redisService;
+            _local = new LocalValueMemoryCacheLayer<TModel>();
+            _redis = new RedisValueCacheLayer<TModel>(redisService);
             _distributedLock = distributedLock;
             _dbExecuteService = dbExecuteService;
         }
 
-        private static string GetLockKey(TKey key)
-        {
-            return $"fb:lock:{key.GetRedisKey()}";
-        }
+        private static string GetLockKey(TKey key) => $"fb:lock:{key.GetRedisKey()}";
 
         protected override async Task<TModel> Get(uint world, TKey key)
         {
             await using var _ = await _distributedLock.Lock(world, GetLockKey(key));
 
-            if (_local.TryGetValue(key.GetRedisKey(), out var localValue))
-            {
-                var value = JsonConvert.DeserializeObject<TModel>(localValue);
-                if (value.Deleted)
-                    return null;
+            var localValue = _local.TryGet(key.GetRedisKey());
+            if (localValue != null)
+                return localValue;
 
-                return value;
-            }
+            var redis = _redis.GetConnection(world, key.GetHash());
+            var redisValue = await _redis.TryGetAsync(redis, key.GetRedisKey());
+            if (redisValue != null)
+                return redisValue;
 
-            var hash = key.GetHash();
-            var redis = hash == null ? _redisService.GetGlobalConnection(world) : _redisService.GetShardConnection(world, hash.Value);
-            if (redis == null)
+            var dbValue = await base.Get(world, key);
+            if (dbValue == null)
                 return null;
 
-            var redisValues = await redis.Connection.JsonGetAsync<TModel>(key.GetRedisKey());
-            if (redisValues != null)
-            {
-                if (redisValues.Deleted)
-                    return null;
+            await _redis.WriteBackAsync(redis, key.GetRedisKey(), dbValue);
+            if (dbValue.Deleted)
+                return null;
 
-                return redisValues;
-            }
-
-            var mysqlValue = await base.Get(world, key);
-            if (mysqlValue != null)
-            {
-                if (!_updateValueExpiryScripts.TryGetValue(redis, out var script))
-                {
-                    script = LuaScript.Prepare(UpdateValueExpiryScript).Load(redis.GetServer());
-                    _updateValueExpiryScripts[redis] = script;
-                }
-
-                await redis.Connection.ScriptEvaluateAsync(script, new
-                {
-                    key = key.GetRedisKey(),
-                    value = JsonConvert.SerializeObject(mysqlValue),
-                    cref = new RedisKey(Const.ReferenceCountKey),
-                    expiry = (int)Const.CacheTimeToLive.TotalSeconds
-                });
-
-                if (mysqlValue.Deleted)
-                    return null;
-
-                return mysqlValue;
-            }
-
-            return null;
+            return dbValue;
         }
 
         protected override sealed Task<IEnumerable<TModel>> GetAll(uint world, TKey key)
@@ -129,8 +65,7 @@ namespace Http.Reepository
 
             foreach (var group in keys.Distinct().GroupBy(k => k.GetHash()))
             {
-                var hash = group.Key;
-                var redis = hash == null ? _redisService.GetGlobalConnection(world) : _redisService.GetShardConnection(world, hash.Value);
+                var redis = _redis.GetConnection(world, group.Key);
                 if (redis == null)
                 {
                     missingKeys.AddRange(group);
@@ -141,12 +76,10 @@ namespace Http.Reepository
                 var localMiss = new List<TKey>();
                 foreach (var key in keyList)
                 {
-                    var redisKey = key.GetRedisKey();
-                    if (_local.TryGetValue(redisKey, out var json))
+                    var localValue = _local.TryGet(key.GetRedisKey());
+                    if (localValue != null)
                     {
-                        var v = JsonConvert.DeserializeObject<TModel>(json);
-                        if (v != null && !v.Deleted)
-                            result.Add(v);
+                        result.Add(localValue);
                     }
                     else
                     {
@@ -156,45 +89,24 @@ namespace Http.Reepository
 
                 if (localMiss.Count > 0)
                 {
-                    var redisKeys = new RedisKey[localMiss.Count + 1];
-                    for (var i = 0; i < localMiss.Count; i++)
-                    {
-                        redisKeys[i] = localMiss[i].GetRedisKey();
-                    }
-                    redisKeys[localMiss.Count] = Const.ReferenceCountKey;
-                    var values = new RedisValue[] { (int)Const.CacheTimeToLive.TotalSeconds };
+                    var redisKeys = localMiss.Select(k => k.GetRedisKey()).ToList();
+                    var redisHits = await _redis.TryGetManyAsync(redis, redisKeys);
+                    var hitKeys = new HashSet<string>(redisHits.Select(x => x.RedisKey.ToString()));
 
-                    if (!_multiValueGetScripts.TryGetValue(redis, out var multiGetScript))
+                    foreach (var (redisKey, json) in redisHits)
                     {
-                        multiGetScript = LuaScript.Prepare(MultiValueGetScript).Load(redis.GetServer());
-                        _multiValueGetScripts[redis] = multiGetScript;
-                    }
-
-                    var multiResult = await redis.Connection.ScriptEvaluateAsync(multiGetScript.Hash, redisKeys, values);
-                    var elements = (RedisResult[])multiResult;
-                    for (var i = 0; i < localMiss.Count; i++)
-                    {
-                        var key = localMiss[i];
-                        var elem = elements[i];
-                        if (elem.IsNull)
-                        {
-                            missingKeys.Add(key);
-                            continue;
-                        }
-                        var jsonStr = elem.ToString();
-                        if (string.IsNullOrEmpty(jsonStr))
-                        {
-                            missingKeys.Add(key);
-                            continue;
-                        }
-                        var val = JsonConvert.DeserializeObject<TModel>(jsonStr);
+                        var val = JsonConvert.DeserializeObject<TModel>(json);
                         if (val == null || val.Deleted)
-                        {
-                            missingKeys.Add(key);
                             continue;
-                        }
+
                         result.Add(val);
-                        _local[redisKeys[i]] = jsonStr;
+                        _local.PutRaw(redisKey, json);
+                    }
+
+                    foreach (var key in localMiss)
+                    {
+                        if (!hitKeys.Contains(key.GetRedisKey().ToString()))
+                            missingKeys.Add(key);
                     }
                 }
             }
@@ -208,31 +120,17 @@ namespace Http.Reepository
                     {
                         result.Add(entity);
                     }
+
                     if (kv.Value.Count == 0)
                         continue;
+
                     var key = kv.Key;
                     var firstEntity = kv.Value[0];
                     await using var _ = await _distributedLock.Lock(world, GetLockKey(key));
 
-                    var hash = key.GetHash();
-                    var redisForKey = hash == null ? _redisService.GetGlobalConnection(world) : _redisService.GetShardConnection(world, hash.Value);
-                    if (redisForKey != null)
-                    {
-                        if (!_updateValueExpiryScripts.TryGetValue(redisForKey, out var script))
-                        {
-                            script = LuaScript.Prepare(UpdateValueExpiryScript).Load(redisForKey.GetServer());
-                            _updateValueExpiryScripts[redisForKey] = script;
-                        }
-
-                        await redisForKey.Connection.ScriptEvaluateAsync(script, new
-                        {
-                            key = key.GetRedisKey(),
-                            value = JsonConvert.SerializeObject(firstEntity),
-                            cref = new RedisKey(Const.ReferenceCountKey),
-                            expiry = (int)Const.CacheTimeToLive.TotalSeconds
-                        });
-                        _local[key.GetRedisKey()] = JsonConvert.SerializeObject(firstEntity);
-                    }
+                    var redis = _redis.GetConnection(world, key.GetHash());
+                    await _redis.WriteBackAsync(redis, key.GetRedisKey(), firstEntity);
+                    _local.Put(key.GetRedisKey(), firstEntity);
                 }
             }
 
@@ -245,19 +143,12 @@ namespace Http.Reepository
             {
                 value.UpdatedDate = DateTime.Now;
 
-                var hash = value.GetHash();
-                var redis = hash == null ? _redisService.GetGlobalConnection(world) : _redisService.GetShardConnection(world, hash.Value);
+                var redis = _redis.GetConnection(world, value.GetHash());
                 if (redis == null)
                     return;
 
-                await redis.Connection.TransactAsync(cmd =>
-                {
-                    cmd.Enqueue(trans => trans.JsonSetAsync(value.GetRedisKey(), value));
-                    cmd.Enqueue(trans => trans.KeyExpireAsync(value.GetRedisKey(), expiry: (TimeSpan?)null));
-                    cmd.Enqueue(trans => trans.HashIncrementAsync(Const.ReferenceCountKey, value.GetRedisKey().ToString()));
-                });
-
-                _local[value.GetRedisKey()] = JsonConvert.SerializeObject(value);
+                await _redis.SetAsync(redis, value.GetRedisKey(), value);
+                _local.Put(value.GetRedisKey(), value);
 
                 var sql = OnUpsert(value);
                 await _dbExecuteService.Post(world, value.GetHash(), sql, value.GetRedisKey().ToString());

--- a/server/log/Repository/LogRepository.cs
+++ b/server/log/Repository/LogRepository.cs
@@ -87,12 +87,20 @@ namespace Log.Repository
                     timestampStr = DateTimeOffset.UtcNow.ToString("yyyy-MM-dd HH:mm:ss");
                 }
 
+                string? transactionId = null;
+                if (log.TryGetProperty("transaction_id", out var txn) &&
+                    txn.ValueKind == JsonValueKind.String)
+                {
+                    transactionId = txn.GetString();
+                }
+
                 return new LogEntry
                 {
                     Timestamp = timestampStr,
                     Event = log.TryGetProperty("event", out var evt) ? evt.GetString() ?? string.Empty : string.Empty,
                     ServerId = log.TryGetProperty("server_id", out var sid) ? sid.GetString() ?? string.Empty : string.Empty,
                     ServerName = log.TryGetProperty("server_name", out var sname) ? sname.GetString() ?? string.Empty : string.Empty,
+                    TransactionId = transactionId,
                     Data = log.TryGetProperty("data", out var data) ? data.GetRawText() : "{}"
                 };
             }
@@ -106,9 +114,9 @@ namespace Log.Repository
         private static string BuildBulkInsertQuery(List<LogEntry> entries)
         {
             var values = string.Join(", ", entries.Select(e =>
-                $"({e.Timestamp.Escape()}, {e.Event.Escape()}, {e.ServerId.Escape()}, {e.ServerName.Escape()}, {e.Data.Escape()})"));
+                $"({e.Timestamp.Escape()}, {e.Event.Escape()}, {e.ServerId.Escape()}, {e.ServerName.Escape()}, {e.TransactionId.Escape()}, {e.Data.Escape()})"));
 
-            return $"INSERT INTO log (`timestamp`, `event`, `server_id`, `server_name`, `data`) VALUES {values}";
+            return $"INSERT INTO log (`timestamp`, `event`, `server_id`, `server_name`, `transaction_id`, `data`) VALUES {values}";
         }
 
         private class LogEntry
@@ -117,6 +125,7 @@ namespace Log.Repository
             public string Event { get; set; } = string.Empty;
             public string ServerId { get; set; } = string.Empty;
             public string ServerName { get; set; } = string.Empty;
+            public string? TransactionId { get; set; }
             public string Data { get; set; } = "{}";
         }
     }

--- a/tools/update-modules.bat
+++ b/tools/update-modules.bat
@@ -81,9 +81,9 @@ XCOPY flatbuffers\build\Debug\flatbuffers.lib %DEST%\lib\flatbuffersd.* /K /D /H
 XCOPY flatbuffers\build\Release\flatbuffers.lib %DEST%\lib\flatbuffers.* /K /D /H /Y
 ROBOCOPY flatbuffers\include\ %DEST%\include\ /E
 
-git clone https://github.com/microsoft/cpp-async
+git clone https://github.com/boyism80/cpp-async
 PUSHD cpp-async
-git checkout v1.1.0
+git checkout v1.1.0-fb
 POPD
 ROBOCOPY cpp-async\include\async\ %DEST%\include\async\ *.h
 


### PR DESCRIPTION
## Summary

- Add execution context propagation across thread, container, timer, acceptor, AMQP, and Lua work paths with `transaction_id` logging support
- Extract HTTP Redis repository cache layers (L1 memory + L2 Redis) for hash and value repositories
- Rename server global variable Lua API from `gv()` to `property()` and migrate related C++/Lua bindings
- Switch cpp-async dependency to `boyism80/cpp-async` tag `v1.1.0-fb` in build scripts and Dockerfile
- Update bot dev config, wiki submodule, and log DB schema for `transaction_id`

## Changes by area

### Execution context propagation
- Add `async_local`, `context`, and `execution_context` types
- Propagate `async::propagation::token` through thread enqueue/dispatch, thread_container, timer, and acceptor packet handling
- Mint and carry `transaction_id` at work origins (packet, AMQP, timer, etc.)
- Wire `transaction_id` into log collector and `LogRepository` bulk insert
- Add `log.transaction_id` column and index in `infra/db/latest.sql`
- Install propagation hooks on `async_executor`

### cpp-async dependency
- `tools/update-modules.bat`: clone `boyism80/cpp-async`, checkout `v1.1.0-fb`
- `server/fb/Dockerfile`: same fork/tag for container builds

### HTTP repository cache refactor
- Add `LocalHashMemoryCacheLayer`, `LocalValueMemoryCacheLayer`
- Add `RedisHashCacheLayer`, `RedisValueCacheLayer`
- Simplify `Repository.RedisHash.cs` and `Repository.RedisValue.cs` to delegate to cache layers

### Server property API rename
- Rename `service::vars` to `service::property` (`vars.h` -> `property.h`)
- Update C++ server bindings (`builtin/server.cpp`, `server.cpp`)
- Migrate Lua scripts from `gv()` to `property()` (NPC scripts, `server.lua`, `init.lua`, `schedule.lua`, `command.lua`)

### Other
- `server/bot/config/config.dev.json`: point bot dev server to `127.0.0.1:3001`
- `wiki` submodule update

## Commits (5)

1. `9f6c6fa5` — chore: update wiki submodule
2. `46d79d5c` — refactor: extract HTTP repository Redis cache layers
3. `df0c738d` — refactor: rename server gv API to property
4. `7ae088c4` — feat: add execution context propagation
5. `fd1baa1a` — chore: update bot dev config for local testing