### PR TITLE
chore: add automated build cache cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           submodules: true
 
+      - name: Prune stale BuildKit cache
+        run: bash tools/prune-build-cache.sh
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -92,6 +95,9 @@ jobs:
         with:
           submodules: true
 
+      - name: Prune stale BuildKit cache
+        run: bash tools/prune-build-cache.sh
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -139,6 +145,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+
+      - name: Prune stale BuildKit cache
+        run: bash tools/prune-build-cache.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -188,6 +197,9 @@ jobs:
         with:
           submodules: true
 
+      - name: Prune stale BuildKit cache
+        run: bash tools/prune-build-cache.sh
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -233,6 +245,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+
+      - name: Prune stale BuildKit cache
+        run: bash tools/prune-build-cache.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -280,6 +295,9 @@ jobs:
         with:
           submodules: true
 
+      - name: Prune stale BuildKit cache
+        run: bash tools/prune-build-cache.sh
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -326,6 +344,9 @@ jobs:
         with:
           submodules: true
 
+      - name: Prune stale BuildKit cache
+        run: bash tools/prune-build-cache.sh
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -371,6 +392,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+
+      - name: Prune stale BuildKit cache
+        run: bash tools/prune-build-cache.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -420,6 +444,9 @@ jobs:
         with:
           submodules: true
 
+      - name: Prune stale BuildKit cache
+        run: bash tools/prune-build-cache.sh
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -468,6 +495,9 @@ jobs:
         with:
           submodules: true
 
+      - name: Prune stale BuildKit cache
+        run: bash tools/prune-build-cache.sh
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -503,6 +533,19 @@ jobs:
           file: server/http/Dockerfile
           build-args: |
             SERVICE=marketplace
+
+  cleanup-cache:
+    runs-on: [self-hosted, linux, build]
+    permissions:
+      contents: read
+      packages: write
+    needs: [build-linux, internal, write-back, gateway, login, game, bot, admin-tool, log, marketplace]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Prune stale GHCR cache
+        run: bash tools/prune-ghcr-cache.sh
 
   deploy:
     runs-on: [self-hosted, linux, master]

--- a/server/bot/main.cpp
+++ b/server/bot/main.cpp
@@ -2,6 +2,7 @@
 #include <boost/program_options.hpp>
 #include <fb/console.h>
 #include <fb/config.h>
+#include <fb/encoding.h>
 #include <fb/model/model.h>
 #include <fb/bot/test_mode.h>
 #include <fb/bot/bot_controller_factory.h>
@@ -13,7 +14,7 @@ namespace po = boost::program_options;
 int main(int argc, char** argv)
 {
 #ifdef _WIN32
-    fb::model::option::decoding(cp949);
+    fb::model::option::decoding(fb::cp949);
 #endif
 
     // Parse command line options

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -5,6 +5,8 @@ BUILD_TYPE=${1:-Debug}
 
 echo "Building with type: $BUILD_TYPE"
 
+bash "$(dirname "$0")/prune-build-cache.sh"
+
 pushd ..
 
 echo "Retrieving external IP..."

--- a/tools/prune-build-cache.sh
+++ b/tools/prune-build-cache.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+CACHE_MAX_AGE="${CACHE_MAX_AGE:-168h}"
+
+docker_cmd() {
+    if sudo docker info >/dev/null 2>&1; then
+        sudo docker "$@"
+    elif docker info >/dev/null 2>&1; then
+        docker "$@"
+    else
+        echo "Docker is not available" >&2
+        exit 1
+    fi
+}
+
+echo "Pruning local BuildKit cache older than ${CACHE_MAX_AGE}..."
+docker_cmd buildx prune --filter "until=${CACHE_MAX_AGE}" --force || true
+docker_cmd builder prune --filter "until=${CACHE_MAX_AGE}" --force || true

--- a/tools/prune-ghcr-cache.sh
+++ b/tools/prune-ghcr-cache.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+OWNER="${GHCR_OWNER:-boyism80}"
+CACHE_MAX_DAYS="${CACHE_MAX_DAYS:-7}"
+PACKAGES=(
+    data
+    build
+    gateway
+    login
+    game
+    bot
+    internal
+    write-back
+    admin-tool
+    log
+    marketplace
+)
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "gh CLI not found, skipping GHCR cache prune"
+    exit 0
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+    echo "gh is not authenticated, skipping GHCR cache prune"
+    exit 0
+fi
+
+if date -u -d "${CACHE_MAX_DAYS} days ago" +%s >/dev/null 2>&1; then
+    CUTOFF_EPOCH=$(date -u -d "${CACHE_MAX_DAYS} days ago" +%s)
+else
+    CUTOFF_EPOCH=$(date -u -v-"${CACHE_MAX_DAYS}"d +%s)
+fi
+
+echo "Pruning untagged GHCR package versions older than ${CACHE_MAX_DAYS} days..."
+
+for pkg in "${PACKAGES[@]}"; do
+    encoded="fb%2F${pkg}"
+    echo "Checking ghcr.io/${OWNER}/fb/${pkg}..."
+
+    gh api --paginate "/users/${OWNER}/packages/container/${encoded}/versions" \
+        --jq ".[] | select((.metadata.container.tags | length) == 0) | select((.created_at | fromdateiso8601) < ${CUTOFF_EPOCH}) | .id" \
+        | while read -r version_id; do
+            if [ -z "${version_id}" ]; then
+                continue
+            fi
+
+            echo "  Deleting untagged version ${version_id}"
+            gh api --method DELETE "/users/${OWNER}/packages/container/${encoded}/versions/${version_id}" || true
+        done
+done


### PR DESCRIPTION
## Summary

- Add prune scripts for local BuildKit cache (7 days) and stale GHCR untagged package versions
- Run local cache prune in `tools/build.sh` and before each Docker build job in GitHub Actions
- Add `cleanup-cache` CI job to prune orphaned GHCR buildcache manifests after image builds
- Fix Windows bot build by qualifying `cp949` in `server/bot/main.cpp`

## Commits

- `8a4f17ae` fix: qualify cp949 in bot main for Windows build
- `54224f01` chore: add automated build cache cleanup