### PR TITLE
fix: use python3 for bot integration protocol CI check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -359,8 +359,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Ensure Python 3
+        run: |
+          if ! command -v python3 >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y python3
+          fi
+          python3 --version
+
       - name: Verify integration protocol registry
-        run: python tools/codegen/integration_protocol/generate.py --check
+        run: python3 tools/codegen/integration_protocol/generate.py --check
 
       - name: Extract metadata
         id: meta


### PR DESCRIPTION
## Summary

- Add an Ensure Python 3 step to the bot job that installs \python3\ via apt when it is missing on the self-hosted runner
- Run the integration protocol registry verification with \python3\ instead of \python\

Fixes the post-merge CI failure from PR #453 where the bot job exited with code 127 (\python: command not found\).