### PR TITLE
fix: server stability, bot transfer reliability, and integration tests

### DIFF
--- a/include/fb/acceptor.h
+++ b/include/fb/acceptor.h
@@ -205,10 +205,16 @@ private:
         {
             fb::logger::fatal(e.what());
         }
+
+        if (socket.is_open())
+            socket.close();
+
         auto fd = socket.fd();
         {
-            auto guard = this->_sockets.enter_write();
-            guard.value().erase(fd);
+            auto  guard = this->_sockets.enter_write();
+            auto& v     = guard.value();
+            if (auto it = v.find(fd); it != v.end() && it->second.get() == &socket)
+                v.erase(it);
         }
     }
 
@@ -226,26 +232,28 @@ private:
 
     async::task<void> on_socket_closed(fb::socket<T>& socket)
     {
+        auto socket_ptr = socket.template shared_from_this_as<fb::socket<T>>();
+
+        if (socket_ptr->data() != nullptr)
+        {
+            try
+            {
+                auto weak = socket_ptr->template weak_from_this_as<fb::socket<T>>();
+                co_await this->threads.switching(weak);
+            }
+            catch (std::exception& e)
+            {
+                fb::logger::fatal("failed to switch thread context: {}", e.what());
+            }
+            catch (...)
+            {
+                fb::logger::fatal("failed to switch thread context: unknown exception");
+            }
+        }
+
         try
         {
-            if (socket.data() == nullptr)
-                co_return;
-
-            auto weak = socket.template weak_from_this_as<fb::socket<T>>();
-            co_await this->threads.switching(weak);
-        }
-        catch (std::exception& e)
-        {
-            fb::logger::fatal("failed to switch thread context: {}", e.what());
-        }
-        catch (...)
-        {
-            fb::logger::fatal("failed to switch thread context: unknown exception");
-        }
-
-        try
-        {
-            co_await this->erase(socket);
+            co_await this->erase(*socket_ptr);
         }
         catch (std::exception& e)
         {
@@ -278,18 +286,29 @@ private:
                     auto  fd    = socket_ptr->fd();
                     auto  guard = this->_sockets.enter_write();
                     auto& v     = guard.value();
-                    if (v.contains(fd))
+                    if (auto it = v.find(fd); it != v.end())
                     {
-                        fb::logger::warn(std::format("socket already exists. fd: {}", fd));
-                        v.erase(fd);
+                        if (it->second.get() != socket_ptr.get())
+                        {
+                            fb::logger::warn(std::format("socket already exists. fd: {}", fd));
+                            auto stale = it->second;
+                            v.erase(it);
+                            if (stale->is_open())
+                                stale->close();
+                        }
                     }
 
-                    v.insert({fd, socket_ptr});
+                    v.insert_or_assign(fd, socket_ptr);
                 }
 
                 async::awaitable_get(this->on_connected(*socket_ptr));
 
-                boost::asio::co_spawn(*this, socket_ptr->recv(), boost::asio::detached);
+                boost::asio::co_spawn(
+                    *this,
+                    [socket_ptr]() -> boost::asio::awaitable<void> {
+                        co_await socket_ptr->recv();
+                    },
+                    boost::asio::detached);
                 this->accept();
             }
             catch (std::exception& e)

--- a/include/fb/acceptor.h
+++ b/include/fb/acceptor.h
@@ -57,7 +57,7 @@ protected:
     socket_container_sync _sockets;
 
 protected:
-    acceptor(boost::asio::io_context& context, std::string_view name, uint16_t port, size_t http_max_concurrent = 500) :
+    acceptor(boost::asio::io_context& context, std::string_view name, uint16_t port, size_t http_max_concurrent = 128) :
         fb::async_executor(context, name, config<uint32_t>("thread:logic")),
         boost::asio::ip::tcp::acceptor(context, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), port)),
         handler(*this),

--- a/include/fb/bot/bot.h
+++ b/include/fb/bot/bot.h
@@ -9,6 +9,7 @@
 #include <boost/endian/conversion.hpp>
 #include <fb/model/model.h>
 #include <fb/bot/hook_params.h>
+#include <fb/logger.h>
 
 namespace fb::bot {
 
@@ -96,7 +97,14 @@ public:
 
             if (auto bot = bot_weak.lock())
             {
+                fb::logger::warn("bot request timeout: bot_id={} response_opcode=0x{:02X}",
+                                 bot->id,
+                                 hook_cmd);
                 bot->remove_hook_by_context(hook_cmd, context_ptr);
+            }
+            else
+            {
+                fb::logger::warn("bot request timeout: bot=<disconnected> response_opcode=0x{:02X}", hook_cmd);
             }
             promise->set_exception(std::make_exception_ptr(std::runtime_error("request timeout")));
         }
@@ -142,7 +150,14 @@ public:
 
             if (auto bot = bot_weak.lock())
             {
+                fb::logger::warn("bot request timeout: bot_id={} response_opcode=0x{:02X}",
+                                 bot->id,
+                                 hook_cmd);
                 bot->remove_hook_by_context(hook_cmd, context_ptr);
+            }
+            else
+            {
+                fb::logger::warn("bot request timeout: bot=<disconnected> response_opcode=0x{:02X}", hook_cmd);
             }
             promise->set_exception(std::make_exception_ptr(std::runtime_error("request timeout")));
         }

--- a/include/fb/bot/bot.h
+++ b/include/fb/bot/bot.h
@@ -97,9 +97,7 @@ public:
 
             if (auto bot = bot_weak.lock())
             {
-                fb::logger::warn("bot request timeout: bot_id={} response_opcode=0x{:02X}",
-                                 bot->id,
-                                 hook_cmd);
+                fb::logger::warn("bot request timeout: bot_id={} response_opcode=0x{:02X}", bot->id, hook_cmd);
                 bot->remove_hook_by_context(hook_cmd, context_ptr);
             }
             else
@@ -150,9 +148,7 @@ public:
 
             if (auto bot = bot_weak.lock())
             {
-                fb::logger::warn("bot request timeout: bot_id={} response_opcode=0x{:02X}",
-                                 bot->id,
-                                 hook_cmd);
+                fb::logger::warn("bot request timeout: bot_id={} response_opcode=0x{:02X}", bot->id, hook_cmd);
                 bot->remove_hook_by_context(hook_cmd, context_ptr);
             }
             else

--- a/include/fb/bot/controller.h
+++ b/include/fb/bot/controller.h
@@ -5,6 +5,7 @@
 #include <fb/bot/container.h>
 #include <fb/synchronized.h>
 #include <fb/protocol/header.h>
+#include <fb/logger.h>
 #include <format>
 
 namespace fb::bot {
@@ -440,6 +441,11 @@ bot<BotType>::request_by_opcode(std::shared_ptr<BotType>                        
 
     auto self_ptr = std::static_pointer_cast<BotType>(target->shared_from_this());
     auto context  = std::make_shared<request_erased_context>(self_ptr, response_opcode);
+
+    fb::logger::debug("bot request start: bot_id={} response_opcode=0x{:02X} timeout_ms={}",
+                      target->id,
+                      response_opcode,
+                      timeout.total_milliseconds());
 
     if (timeout > 0s)
     {

--- a/include/fb/bot/game_bot.h
+++ b/include/fb/bot/game_bot.h
@@ -89,10 +89,11 @@ private:
     uint32_t                        _oid = 0;
     point<uint16_t>                 _position;
     fb::stream                      _transfer_buffer;
-    DIRECTION                       _direction = DIRECTION::BOTTOM;
-    uint16_t                        _look      = 0;
-    uint8_t                         _color     = 0;
-    bool                            _dead      = false;
+    uint32_t                        _transfer_from_bot_id = 0;
+    DIRECTION                       _direction            = DIRECTION::BOTTOM;
+    uint16_t                        _look                 = 0;
+    uint8_t                         _color                = 0;
+    bool                            _dead                 = false;
     std::set<std::string>           _active_buffs;
     std::map<uint8_t, simple_item>  _items;
     std::map<uint8_t, simple_spell> _spells;
@@ -159,6 +160,9 @@ public:
     void inited(bool value);
 
     const fb::stream& transfer_buffer() const;
+
+    uint32_t transfer_from_bot_id() const;
+    void     set_transfer_from_bot_id(uint32_t value);
 
     DIRECTION direction() const;
     void      set_direction(DIRECTION value);

--- a/include/fb/bot/game_controller.h
+++ b/include/fb/bot/game_controller.h
@@ -4,6 +4,7 @@
 #include <fb/bot/controller.h>
 #include <fb/game/protocol.h>
 #include <fb/bot/game_bot.h>
+#include <fb/logger.h>
 
 namespace fb::bot {
 
@@ -49,6 +50,8 @@ public:
         {
             if (completed.exchange(true))
                 return;
+
+            fb::logger::warn("bot transfer timeout: bot={}", name);
 
             if (auto controller = controller_weak.lock())
                 controller->remove_transfer_context(name);
@@ -139,6 +142,7 @@ private:
 public:
     bool register_transfer_context(const fb::protocol::header& protocol, std::shared_ptr<transfer_context> context);
     void remove_transfer_context(std::string name);
+    bool has_transfer_context(std::string_view name) const;
     bool invoke_transfer_context(std::string name, std::shared_ptr<game_bot> bot);
 };
 

--- a/include/fb/bot/game_controller.h
+++ b/include/fb/bot/game_controller.h
@@ -24,15 +24,15 @@ public:
 
         std::shared_ptr<promise_type>      promise;
         std::shared_ptr<fb::timer>         timer;
-        std::string                        name;
+        uint32_t                           source_bot_id;
         std::atomic<bool>                  completed;
         std::weak_ptr<game_bot_controller> controller_weak;
 
         transfer_context(std::shared_ptr<promise_type>      promise,
-                         std::string                        name,
+                         uint32_t                           source_bot_id,
                          std::weak_ptr<game_bot_controller> controller) :
             promise(promise),
-            name(name),
+            source_bot_id(source_bot_id),
             controller_weak(controller)
         { }
 
@@ -51,10 +51,10 @@ public:
             if (completed.exchange(true))
                 return;
 
-            fb::logger::warn("bot transfer timeout: bot={}", name);
+            fb::logger::warn("bot transfer timeout: source_bot_id={}", source_bot_id);
 
             if (auto controller = controller_weak.lock())
-                controller->remove_transfer_context(name);
+                controller->remove_transfer_context(source_bot_id);
 
             promise->set_exception(std::make_exception_ptr(std::runtime_error("request timeout")));
         }
@@ -66,7 +66,7 @@ public:
     };
 
 private:
-    std::unordered_map<std::string, std::shared_ptr<transfer_context>> _transfer_contexts;
+    std::unordered_map<uint32_t, std::shared_ptr<transfer_context>> _transfer_contexts;
 
 protected:
     game_bot_controller(bot_container& container);
@@ -106,7 +106,7 @@ private:
     template <bool Detailed> async::task<void> on_update_external(game_bot&                                   bot,
                                                                   const game_resp::update_external<Detailed>& response)
     {
-        if (bot.oid() != response.oid)
+        if (bot.oid() != 0 && bot.oid() != response.oid)
             co_return;
 
         if constexpr (Detailed)
@@ -141,9 +141,9 @@ private:
 
 public:
     bool register_transfer_context(const fb::protocol::header& protocol, std::shared_ptr<transfer_context> context);
-    void remove_transfer_context(std::string name);
-    bool has_transfer_context(std::string_view name) const;
-    bool invoke_transfer_context(std::string name, std::shared_ptr<game_bot> bot);
+    void remove_transfer_context(uint32_t source_bot_id);
+    bool has_transfer_context(uint32_t source_bot_id) const;
+    bool invoke_transfer_context(uint32_t source_bot_id, std::shared_ptr<game_bot> bot);
 };
 
 } // namespace fb::bot

--- a/include/fb/bot/integration/test_case.h
+++ b/include/fb/bot/integration/test_case.h
@@ -78,6 +78,7 @@ public:
 private:
     async::task<void> execute_parallel_scenario(std::shared_ptr<parallel_scenarios_context> context, uint32_t index);
     void              mark_bot_logged_in(game_bot& bot);
+    void              try_complete_transfer(game_bot& bot);
 
 protected:
     virtual generator<scenario_t> on_generate_scenario() = 0;

--- a/include/fb/config.h
+++ b/include/fb/config.h
@@ -8,7 +8,6 @@
 #include <fstream>
 #include <json/json.h>
 #include <sstream>
-#include <mutex>
 #include <format>
 #include <filesystem>
 #include <boost/program_options.hpp>
@@ -156,6 +155,27 @@ inline void set_config_path(std::string_view path)
     config_path_storage(path, true);
 }
 
+inline Json::Value& config_root()
+{
+    static Json::Value root;
+    return root;
+}
+
+inline void load_config_file()
+{
+    auto config_path = get_config_path();
+    if (config_path.empty())
+        throw std::runtime_error("Config system not initialized. Call init_config() or set_config_path() first.");
+
+    auto ifstream = std::ifstream(config_path);
+    if (ifstream.is_open() == false)
+        throw std::runtime_error("cannot load config file " + config_path);
+
+    Json::Reader reader;
+    if (reader.parse(ifstream, config_root()) == false)
+        throw std::runtime_error("cannot parse json config file " + config_path);
+}
+
 inline bool init_config(std::string_view config_path)
 {
     try
@@ -167,6 +187,7 @@ inline bool init_config(std::string_view config_path)
         }
 
         set_config_path(config_path);
+        load_config_file();
         return true;
     }
     catch (const std::exception& e)
@@ -178,37 +199,10 @@ inline bool init_config(std::string_view config_path)
 
 inline static const Json::Value& config_node(std::string_view k)
 {
-    static std::once_flag flag;
-    static Json::Value    ist;
+    if (get_config_path().empty())
+        throw std::runtime_error("Config system not initialized. Call init_config() or set_config_path() first.");
 
-    std::call_once(flag, [] {
-        auto config_path = get_config_path();
-        if (config_path.empty())
-            throw std::runtime_error("Config system not initialized. Call init_config() or set_config_path() first.");
-
-        auto ifstream = std::ifstream{};
-        try
-        {
-            ifstream.open(config_path);
-            if (ifstream.is_open() == false)
-                throw std::runtime_error("cannot load config file " + config_path);
-
-            Json::Reader reader;
-            if (reader.parse(ifstream, ist) == false)
-                throw std::runtime_error("cannot parse json config file " + config_path);
-
-            ifstream.close();
-        }
-        catch (std::exception& e)
-        {
-            if (ifstream.is_open())
-                ifstream.close();
-
-            throw e;
-        }
-    });
-
-    const auto* node    = &ist;
+    const auto* node    = &config_root();
     auto        sstream = std::istringstream{std::string(k)};
     auto        buffer  = std::string{};
     while (std::getline(sstream, buffer, ':'))

--- a/include/fb/game/character.h
+++ b/include/fb/game/character.h
@@ -353,8 +353,7 @@ public:
     void              foreach_enqueue(const std::vector<std::string>& names, character_async_function_t&& fn, character_function_t_miss miss = nullptr) const;
     async::task<void> invoke(std::string_view name, character_function_t fn, character_function_t_miss miss = nullptr) const;
     async::task<void> invoke_async(std::string_view name, character_async_function_t fn, character_function_t_miss miss = nullptr) const;
-
-    void broadcast(std::string_view message, MESSAGE_TYPE type);
+    void              broadcast(std::string_view message, MESSAGE_TYPE type);
     async::task<void> broadcast(std::string_view message, MESSAGE_TYPE type, BROADCAST_TYPE broadcast_type);
     async::task<void> on_broadcast(const fb::protocol::internal::response::Broadcast& resp);
     void              update_time(uint8_t hours);

--- a/include/fb/game/item/base.h
+++ b/include/fb/game/item/base.h
@@ -37,7 +37,7 @@ public:
     struct initial_params : fb::game::object::initial_params
     {
     public:
-        uint16_t                           count       = 1;
+        uint16_t                           count = 1;
         std::optional<fb::model::datetime> expire_time;
     };
 

--- a/include/fb/game/map.h
+++ b/include/fb/game/map.h
@@ -147,6 +147,7 @@ public:
     void                           invoke_init_script(const std::shared_ptr<fb::game::map>& map);
     async::task<void>              invoke_init_script_wait(const std::shared_ptr<fb::game::map>& map);
     void                           spawn_npc(const fb::model::npc_spawn& spawn);
+    async::task<void>              cleanup();
     std::shared_ptr<fb::game::map> name2map(std::string_view name) const;
 
     void rezen_force();

--- a/include/fb/http_client.h
+++ b/include/fb/http_client.h
@@ -3,6 +3,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <format>
 #include <functional>
 #include <map>
 #include <mutex>
@@ -11,7 +12,12 @@
 #include <string_view>
 #include <vector>
 #include <boost/asio/awaitable.hpp>
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/connect.hpp>
 #include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <boost/asio/use_awaitable.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
 #include <boost/beast/version.hpp>
@@ -68,6 +74,188 @@ private:
         });
     }
 
+    struct http_endpoint
+    {
+        std::string host;
+        std::string port;
+    };
+
+    static http_endpoint parse_http_endpoint(std::string host_url)
+    {
+        if (host_url.rfind("http://", 0) == 0)
+            host_url.erase(0, 7);
+        else if (host_url.rfind("https://", 0) == 0)
+            host_url.erase(0, 8);
+
+        const auto colon_pos = host_url.find(':');
+        if (colon_pos == std::string::npos)
+            return {.host = std::move(host_url), .port = "80"};
+
+        return {.host = host_url.substr(0, colon_pos), .port = host_url.substr(colon_pos + 1)};
+    }
+
+    class http_request_deadline
+    {
+    public:
+        http_request_deadline(boost::asio::any_io_executor        executor,
+                              boost::asio::ip::tcp::socket&       socket,
+                              std::chrono::steady_clock::duration timeout) :
+            _socket(socket),
+            _timer(std::move(executor))
+        {
+            _timer.expires_after(timeout);
+            _timer.async_wait([this](const boost::system::error_code& ec) {
+                if (ec || _released.load(std::memory_order_acquire))
+                    return;
+
+                boost::system::error_code cancel_ec;
+                _socket.cancel(cancel_ec);
+            });
+        }
+
+        void release()
+        {
+            if (_released.load(std::memory_order_acquire))
+                return;
+
+            _released.store(true, std::memory_order_release);
+            boost::system::error_code ec;
+            _timer.cancel(ec);
+        }
+
+        ~http_request_deadline()
+        {
+            release();
+        }
+
+    private:
+        boost::asio::ip::tcp::socket& _socket;
+        boost::asio::steady_timer     _timer;
+        std::atomic<bool>             _released{false};
+    };
+
+    static void close_http_socket(boost::asio::ip::tcp::socket& socket)
+    {
+        boost::system::error_code ec;
+        socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
+        socket.close(ec);
+    }
+
+    static std::vector<uint8_t>
+    response_body_bytes(const boost::beast::http::response<boost::beast::http::dynamic_body>& res)
+    {
+        auto body_bytes = std::vector<uint8_t>{};
+        if (res.body().size() > 0)
+            body_bytes.reserve(res.body().size());
+
+        for (const auto& seq : res.body().data())
+        {
+            const auto buf      = seq;
+            const auto data_ptr = static_cast<const uint8_t*>(buf.data());
+            body_bytes.insert(body_bytes.end(), data_ptr, data_ptr + buf.size());
+        }
+
+        return body_bytes;
+    }
+
+    template <typename Request>
+    boost::asio::awaitable<std::vector<uint8_t>> exchange_http_async(boost::asio::io_context&            io_context,
+                                                                     const http_endpoint&                endpoint,
+                                                                     std::chrono::steady_clock::duration timeout,
+                                                                     Request                             request)
+    {
+        auto resolver = boost::asio::ip::tcp::resolver{io_context};
+        auto socket   = boost::asio::ip::tcp::socket{io_context};
+
+        http_request_deadline deadline{io_context.get_executor(), socket, timeout};
+
+        const auto results = co_await resolver.async_resolve(endpoint.host, endpoint.port, boost::asio::use_awaitable);
+        co_await boost::asio::async_connect(socket, results, boost::asio::use_awaitable);
+
+        co_await boost::beast::http::async_write(socket, request, boost::asio::use_awaitable);
+
+        auto buffer = boost::beast::flat_buffer{};
+        auto res    = boost::beast::http::response<boost::beast::http::dynamic_body>{};
+        co_await boost::beast::http::async_read(socket, buffer, res, boost::asio::use_awaitable);
+
+        deadline.release();
+        close_http_socket(socket);
+
+        co_return response_body_bytes(res);
+    }
+
+    static std::runtime_error wrap_http_error(std::string_view operation, const std::exception& e)
+    {
+        return std::runtime_error(std::format("HTTP {} request failed: {}", operation, e.what()));
+    }
+
+    boost::asio::awaitable<std::vector<uint8_t>> boost_get_raw_async(std::string                         host,
+                                                                     std::string                         path,
+                                                                     std::map<std::string, std::string>  headers,
+                                                                     std::chrono::steady_clock::duration timeout)
+    {
+        try
+        {
+            auto& io_context = static_cast<boost::asio::io_context&>(this->_executor);
+            auto  endpoint   = parse_http_endpoint(std::move(host));
+
+            auto req =
+                boost::beast::http::request<boost::beast::http::empty_body>{boost::beast::http::verb::get,
+                                                                            url_encode(UTF8(path, PLATFORM::WINDOWS)),
+                                                                            11};
+            req.set(boost::beast::http::field::host, endpoint.host);
+            req.set(boost::beast::http::field::user_agent, BOOST_BEAST_VERSION_STRING);
+            for (const auto& [name, value] : headers)
+                req.set(name, value);
+
+            co_return co_await exchange_http_async(io_context, endpoint, timeout, std::move(req));
+        }
+        catch (const std::exception& e)
+        {
+            throw wrap_http_error("GET", e);
+        }
+        catch (...)
+        {
+            throw std::runtime_error("HTTP GET request failed: Unknown error occurred");
+        }
+    }
+
+    boost::asio::awaitable<std::vector<uint8_t>> boost_post_raw_async(std::string                         host,
+                                                                      std::string                         path,
+                                                                      std::map<std::string, std::string>  headers,
+                                                                      std::chrono::steady_clock::duration timeout,
+                                                                      std::vector<uint8_t>                body)
+    {
+        try
+        {
+            auto& io_context = static_cast<boost::asio::io_context&>(this->_executor);
+            auto  endpoint   = parse_http_endpoint(std::move(host));
+
+            auto req = boost::beast::http::request<boost::beast::http::vector_body<uint8_t>>{
+                boost::beast::http::verb::post,
+                url_encode(UTF8(path, PLATFORM::WINDOWS)),
+                11};
+
+            req.set(boost::beast::http::field::host, endpoint.host);
+            req.set(boost::beast::http::field::user_agent, BOOST_BEAST_VERSION_STRING);
+            for (const auto& [name, value] : headers)
+                req.set(name, value);
+
+            req.body() = std::move(body);
+            req.prepare_payload();
+
+            co_return co_await exchange_http_async(io_context, endpoint, timeout, std::move(req));
+        }
+        catch (const std::exception& e)
+        {
+            throw wrap_http_error("POST", e);
+        }
+        catch (...)
+        {
+            throw std::runtime_error("HTTP POST request failed: Unknown error occurred");
+        }
+    }
+
 public:
     /**
      * Constructs the HTTP client with an external concurrency limit.
@@ -83,157 +271,6 @@ public:
     http_client& operator= (const http_client&) = delete;
     ~http_client()                              = default;
 
-private:
-    boost::asio::awaitable<std::vector<uint8_t>> boost_get_raw_async(std::string                         host,
-                                                                     std::string                         path,
-                                                                     std::map<std::string, std::string>  headers,
-                                                                     std::chrono::steady_clock::duration timeout)
-    {
-        try
-        {
-            auto raw_host = host;
-            if (raw_host.rfind("http://", 0) == 0)
-                raw_host.erase(0, 7);
-            else if (raw_host.rfind("https://", 0) == 0)
-                raw_host.erase(0, 8);
-
-            auto const colon_pos = raw_host.find(':');
-            auto const host_name = (colon_pos == std::string::npos ? raw_host : raw_host.substr(0, colon_pos));
-            auto const port = (colon_pos == std::string::npos ? std::string("80") : raw_host.substr(colon_pos + 1));
-
-            auto& io_context = static_cast<boost::asio::io_context&>(this->_executor);
-            auto  resolver   = boost::asio::ip::tcp::resolver{io_context};
-            auto  stream     = boost::beast::tcp_stream{io_context};
-
-            stream.expires_after(timeout);
-            auto const results = co_await resolver.async_resolve(host_name, port, boost::asio::use_awaitable);
-            co_await stream.async_connect(results, boost::asio::use_awaitable);
-
-            auto req =
-                boost::beast::http::request<boost::beast::http::empty_body>{boost::beast::http::verb::get,
-                                                                            url_encode(UTF8(path, PLATFORM::WINDOWS)),
-                                                                            11};
-            req.set(boost::beast::http::field::host, host_name);
-            req.set(boost::beast::http::field::user_agent, BOOST_BEAST_VERSION_STRING);
-            for (auto const& h : headers)
-            {
-                req.set(h.first, h.second);
-            }
-
-            stream.expires_after(timeout);
-            co_await boost::beast::http::async_write(stream, req, boost::asio::use_awaitable);
-
-            auto buffer = boost::beast::flat_buffer{};
-            auto res    = boost::beast::http::response<boost::beast::http::dynamic_body>{};
-            stream.expires_after(timeout);
-            co_await boost::beast::http::async_read(stream, buffer, res, boost::asio::use_awaitable);
-
-            auto body_bytes = std::vector<uint8_t>{};
-            if (res.body().size() > 0)
-            {
-                body_bytes.reserve(res.body().size());
-            }
-            for (auto const& seq : res.body().data())
-            {
-                auto buf      = seq; // boost::asio::const_buffer
-                auto data_ptr = static_cast<const uint8_t*>(buf.data());
-                body_bytes.insert(body_bytes.end(), data_ptr, data_ptr + buf.size());
-            }
-
-            auto ec = boost::beast::error_code{};
-            stream.socket().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
-
-            co_return body_bytes;
-        }
-        catch (const std::exception& e)
-        {
-            throw std::runtime_error(std::format("HTTP GET request failed: {}", e.what()));
-        }
-        catch (...)
-        {
-            throw std::runtime_error("HTTP GET request failed: Unknown error occurred");
-        }
-    }
-
-private:
-    boost::asio::awaitable<std::vector<uint8_t>> boost_post_raw_async(std::string                         host,
-                                                                      std::string                         path,
-                                                                      std::map<std::string, std::string>  headers,
-                                                                      std::chrono::steady_clock::duration timeout,
-                                                                      std::vector<uint8_t>                body)
-    {
-        try
-        {
-            auto raw_host = host;
-            if (raw_host.rfind("http://", 0) == 0)
-                raw_host.erase(0, 7);
-            else if (raw_host.rfind("https://", 0) == 0)
-                raw_host.erase(0, 8);
-
-            auto const colon_pos = raw_host.find(':');
-            auto const host_name = (colon_pos == std::string::npos ? raw_host : raw_host.substr(0, colon_pos));
-            auto const port = (colon_pos == std::string::npos ? std::string("80") : raw_host.substr(colon_pos + 1));
-
-            auto& io_context = static_cast<boost::asio::io_context&>(this->_executor);
-            auto  resolver   = boost::asio::ip::tcp::resolver{io_context};
-            auto  stream     = boost::beast::tcp_stream{io_context};
-
-            stream.expires_after(timeout);
-            auto const results = co_await resolver.async_resolve(host_name, port, boost::asio::use_awaitable);
-            co_await stream.async_connect(results, boost::asio::use_awaitable);
-
-            auto req = boost::beast::http::request<boost::beast::http::vector_body<uint8_t>>{
-                boost::beast::http::verb::post,
-                url_encode(UTF8(path, PLATFORM::WINDOWS)),
-                11};
-
-            req.set(boost::beast::http::field::host, host_name);
-            req.set(boost::beast::http::field::user_agent, BOOST_BEAST_VERSION_STRING);
-
-            for (auto const& h : headers)
-            {
-                req.set(h.first, h.second);
-            }
-
-            req.body() = body;
-            req.prepare_payload();
-
-            stream.expires_after(timeout);
-            co_await boost::beast::http::async_write(stream, req, boost::asio::use_awaitable);
-
-            auto buffer = boost::beast::flat_buffer{};
-            auto res    = boost::beast::http::response<boost::beast::http::dynamic_body>{};
-            stream.expires_after(timeout);
-            co_await boost::beast::http::async_read(stream, buffer, res, boost::asio::use_awaitable);
-
-            auto body_bytes = std::vector<uint8_t>{};
-            if (res.body().size() > 0)
-            {
-                body_bytes.reserve(res.body().size());
-            }
-            for (auto const& seq : res.body().data())
-            {
-                auto const buf      = seq;
-                auto const data_ptr = static_cast<const uint8_t*>(buf.data());
-                body_bytes.insert(body_bytes.end(), data_ptr, data_ptr + buf.size());
-            }
-
-            auto ec = boost::beast::error_code{};
-            stream.socket().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
-
-            co_return body_bytes;
-        }
-        catch (const std::exception& e)
-        {
-            throw std::runtime_error(std::format("HTTP request failed: {}", e.what()));
-        }
-        catch (...)
-        {
-            throw std::runtime_error("HTTP request failed: Unknown error occurred");
-        }
-    }
-
-public:
     template <typename T> async::task<T> get(std::string_view service, std::string_view path)
     {
         auto  service_str = std::string(service);

--- a/infra/pulumi/game.js
+++ b/infra/pulumi/game.js
@@ -56,7 +56,7 @@ module.exports = function () {
                         exp_multiplier: 1.0,
                         drop_rate_multiplier: 1.0,
                         http: {
-                            max_concurrent: 500
+                            max_concurrent: 128
                         }
                     }
 

--- a/infra/pulumi/gateway.js
+++ b/infra/pulumi/gateway.js
@@ -45,7 +45,7 @@ module.exports = function () {
                     }
                 },
                 http: {
-                    max_concurrent: 500
+                    max_concurrent: 128
                 },
                 client: {
                     version: conf.gateway.client.version,

--- a/infra/pulumi/login.js
+++ b/infra/pulumi/login.js
@@ -74,7 +74,7 @@ module.exports = function () {
                         max: 16
                     },
                     http: {
-                        max_concurrent: 500
+                        max_concurrent: 128
                     }
                 }
 

--- a/scripts/integration/door_test.lua
+++ b/scripts/integration/door_test.lua
@@ -12,6 +12,67 @@ local function expect_door_message(text)
     end
 end
 
+local function expect_door_toggle_message(packet)
+    if packet.type ~= "STATE" then
+        return false
+    end
+    return packet.text == MESSAGE_DOOR_CLOSE or packet.text == MESSAGE_DOOR_OPEN
+end
+
+local function format_position(pos)
+    if pos == nil then
+        return "nil"
+    end
+    return string.format("(%s,%s)", tostring(pos[1]), tostring(pos[2]))
+end
+
+local function log_bot_state(bot, label)
+    log("debug", string.format(
+        "Door test [%s]: map=%s pos=%s oid=%s",
+        label,
+        tostring(bot:map()),
+        format_position(bot:position()),
+        tostring(bot:oid())))
+end
+
+local function request_door_toggle(bot, label)
+    log("debug", string.format("Door test: %s — door toggle click #1", label))
+    local first = bot:request(resp.message, protocol.door(), expect_door_toggle_message)
+    if first == false or first == nil then
+        log("debug", string.format(
+            "Door test: %s — door toggle click #1 failed (no STATE close/open within timeout)",
+            label))
+        log_bot_state(bot, label .. " after fail")
+        return false
+    end
+
+    log("debug", string.format("Door test: %s — door toggle click #1 ok: %s", label, first.text))
+
+    local second_expected
+    if first.text == MESSAGE_DOOR_CLOSE then
+        second_expected = MESSAGE_DOOR_OPEN
+    elseif first.text == MESSAGE_DOOR_OPEN then
+        second_expected = MESSAGE_DOOR_CLOSE
+    else
+        log("debug", string.format("Door test: %s — unexpected first toggle text: %s", label, first.text))
+        return false
+    end
+
+    log("debug", string.format("Door test: %s — door toggle click #2 expect: %s", label, second_expected))
+    local second = bot:request(resp.message, protocol.door(), expect_door_message(second_expected))
+    if second == false or second == nil then
+        log("debug", string.format(
+            "Door test: %s — door toggle click #2 failed (expected %s)",
+            label,
+            second_expected))
+        log_bot_state(bot, label .. " after fail")
+        return false
+    end
+
+    log("debug", string.format("Door test: %s — door toggle click #2 ok: %s", label, second.text))
+    return true
+end
+
 test_suite {
     name      = "Door Test",
     bot_count = 1,
@@ -30,10 +91,16 @@ test_suite {
 
             log("debug", "Door test: moving to 국내성")
             bot:transfer(protocol.chat(false, "/맵이동 국내성 109 13"))
-            bot:direction("TOP")
+            log_bot_state(bot, "after transfer")
+            ctx:sleep(500)
 
-            bot:request(resp.message, protocol.door(), expect_door_message(MESSAGE_DOOR_CLOSE))
-            bot:request(resp.message, protocol.door(), expect_door_message(MESSAGE_DOOR_OPEN))
+            bot:direction("TOP")
+            log_bot_state(bot, "after direction TOP")
+            ctx:sleep(200)
+
+            if request_door_toggle(bot, "door (109,13)") == false then
+                return false
+            end
 
             bot:create_item("파란열쇠", 1)
             log("debug", "Door test: creating 파란열쇠")
@@ -52,8 +119,9 @@ test_suite {
             bot:map_move("국내성", 110, 13)
             log("debug", "Door test: moving to new door location")
 
-            bot:request(resp.message, protocol.door(), expect_door_message(MESSAGE_DOOR_CLOSE))
-            bot:request(resp.message, protocol.door(), expect_door_message(MESSAGE_DOOR_OPEN))
+            if request_door_toggle(bot, "door (110,13)") == false then
+                return false
+            end
             bot:request(resp.message, protocol.item_active(0), expect_door_message(MESSAGE_DOOR_OPEN))
 
             return true

--- a/scripts/integration/scenarios/skill/special.lua
+++ b/scripts/integration/scenarios/skill/special.lua
@@ -16,28 +16,33 @@ local NAKRANG_ROOM = "낙랑의방"
 local NEARBY_MOB_CLEAR_RANGE = 3
 
 local function restore_position(caster, map_name, position)
+    slog("restore_position: enter target=%s pos=(%s,%s)",
+        tostring(map_name),
+        tostring(position and position[1]),
+        tostring(position and position[2]))
+
     if map_name == nil or position == nil then
         slog("restore_position: missing map_name or position")
         return false
     end
 
-    local map_model = id2map(caster:map())
+    local map_id = caster:map()
+    local map_model = id2map(map_id)
     if map_model == nil then
-        slog("restore_position: id2map(%d) not found", caster:map())
+        slog("restore_position: id2map(%d) not found", map_id)
         return false
     end
 
-    if map_model:name() == map_name and skill.positions_equal(caster:position(), position) then
-        return true
-    end
+    local current = caster:position()
+    local current_name = map_model:name()
+    slog("restore_position: current map=%s (id=%d) pos=(%d,%d) target map=%s pos=(%d,%d)",
+        current_name, map_id, current[1], current[2],
+        map_name, position[1], position[2])
 
-    if map_model:name() == map_name then
-        caster:map_move(map_name, position[1], position[2])
-        return true
-    end
-
-    caster:transfer(protocol.chat(false, string.format(
-        "/맵이동 %s %d %d", map_name, position[1], position[2])))
+    local cmd = string.format("/맵이동 %s %d %d", map_name, position[1], position[2])
+    slog("restore_position: branch=transfer cmd=%s", cmd)
+    caster:transfer(protocol.chat(false, cmd))
+    slog("restore_position: transfer returned")
     return true
 end
 

--- a/scripts/integration/scenarios/skill/target.lua
+++ b/scripts/integration/scenarios/skill/target.lua
@@ -10,8 +10,6 @@ local skill = require("integration.lib.skill")
 local CASES = {
     {
         name = "공력주입",
-        response = resp.update_internal,
-        cast_type = "TARGET",
         pre = function(caster, target, state)
             caster:setup_bot_stats(100000, 100000)
             target:setup_bot_stats(100000, 100000)
@@ -20,21 +18,23 @@ local CASES = {
             state.injected = caster:mp()
             state.target_before_mp = target:mp()
         end,
-        condition = function(packet)
-            if packet.ch_mp == 0 then
-                return true
-            end
-            return nil
-        end,
-        post = function(caster, target, state, packet)
-            if packet.ch_mp ~= 0 then
+        cast = function(caster, target, slot, state)
+            local expected = math.min(target:base_mp(), state.target_before_mp + state.injected)
+            local target_result = caster:request_on(
+                target,
+                resp.update_internal,
+                protocol.spell_cast("TARGET", slot, "", target:oid(), target:position()),
+                function(p)
+                    return p.ch_mp == expected
+                end)
+            if target_result == false or target_result == nil then
                 return false
             end
-            local expected = math.min(target:base_mp(), state.target_before_mp + state.injected)
-            local result = target:request(resp.update_internal, protocol.self_info(), function(p)
-                return p.ch_mp == expected
-            end)
-            return result ~= false and result ~= nil
+            if caster:mp() ~= 0 then
+                return false
+            end
+            state.packet = target_result
+            return true
         end,
     },
     {

--- a/scripts/integration/scenarios/skill/target.lua
+++ b/scripts/integration/scenarios/skill/target.lua
@@ -30,6 +30,9 @@ local CASES = {
             if target_result == false or target_result == nil then
                 return false
             end
+
+            caster:sleep(1000)
+
             if caster:mp() ~= 0 then
                 return false
             end

--- a/server/bot/src/builtin/game_bot_builtin.cpp
+++ b/server/bot/src/builtin/game_bot_builtin.cpp
@@ -27,7 +27,7 @@ constexpr auto INTEGRATION_DEFAULT_TIMEOUT = 30s;
 constexpr auto INTEGRATION_DEFAULT_TIMEOUT = 10s;
 #endif
 
-[[noreturn]] void lua_arg_error(lua_State* L, int index, const char* expected)
+void lua_arg_error(lua_State* L, int index, const char* expected)
 {
     luaL_error(L, "argument %d must be %s", index, expected);
 }

--- a/server/bot/src/builtin/game_bot_builtin.cpp
+++ b/server/bot/src/builtin/game_bot_builtin.cpp
@@ -1091,28 +1091,31 @@ int builtin::game_bot::builtin_transfer(lua_State* L)
     auto request = lua_protocol::to_request(L, 2);
     auto bot_ptr = bot;
 
+    auto weak_slot = static_cast<std::weak_ptr<fb::bot::game_bot>*>(lua_touserdata(*lua, 1));
+    if (weak_slot == nullptr)
+        return 0;
+
+    auto result = std::make_shared<std::shared_ptr<fb::bot::game_bot>>();
+
     auto builder  = lua->new_co_builder();
-    builder.yield = [lua, bot_ptr, request]() -> async::task<void> {
+    builder.yield = [bot_ptr, request, result]() -> async::task<void> {
         if (bot_ptr == nullptr)
             co_return;
 
-        auto result = co_await bot_ptr->transfer(*request, INTEGRATION_DEFAULT_TIMEOUT);
-        if (result == nullptr)
-            co_return;
-
-        auto* L_state = static_cast<lua_State*>(*lua);
-        auto* lua_ctx = fb::lua::get(L_state);
-        if (lua_ctx == nullptr || lua_ctx->is_obj(1) == false)
-            co_return;
-
-        auto allocated = static_cast<std::weak_ptr<fb::bot::game_bot>*>(lua_touserdata(L_state, 1));
-        if (allocated == nullptr)
-            co_return;
-
-        allocated->~weak_ptr<fb::bot::game_bot>();
-        new (allocated) std::weak_ptr<fb::bot::game_bot>(result);
+        *result = co_await bot_ptr->transfer(*request, INTEGRATION_DEFAULT_TIMEOUT);
     };
-    builder.resume = []() -> async::task<int> {
+    builder.resume = [weak_slot, result]() -> async::task<int> {
+        if (*result == nullptr)
+            co_return 0;
+
+        if (weak_slot == nullptr)
+        {
+            fb::logger::warn("builtin transfer: userdata not updated (null weak_slot)");
+            co_return 0;
+        }
+
+        weak_slot->~weak_ptr<fb::bot::game_bot>();
+        new (weak_slot) std::weak_ptr<fb::bot::game_bot>(*result);
         co_return 0;
     };
     return builder.run();

--- a/server/bot/src/game_bot.cpp
+++ b/server/bot/src/game_bot.cpp
@@ -82,6 +82,16 @@ const fb::stream& game_bot::transfer_buffer() const
     return this->_transfer_buffer;
 }
 
+uint32_t game_bot::transfer_from_bot_id() const
+{
+    return this->_transfer_from_bot_id;
+}
+
+void game_bot::set_transfer_from_bot_id(uint32_t value)
+{
+    this->_transfer_from_bot_id = value;
+}
+
 DIRECTION game_bot::direction() const
 {
     return this->_direction;
@@ -697,7 +707,10 @@ async::task<void> game_bot::change_mp(uint32_t mp, std::chrono::milliseconds tim
 async::task<void> game_bot::direction(DIRECTION direction, std::chrono::milliseconds timeout)
 {
     if (this->_direction == direction)
+    {
+        fb::logger::debug("bot direction skipped: bot_id={} already facing {}", this->id, enum_tostring(direction));
         co_return;
+    }
 
     try
     {
@@ -708,8 +721,13 @@ async::task<void> game_bot::direction(DIRECTION direction, std::chrono::millisec
             },
             timeout);
     }
-    catch (std::exception&)
-    { }
+    catch (const std::exception& e)
+    {
+        fb::logger::warn("bot direction failed: bot_id={} direction={} error={}",
+                         this->id,
+                         enum_tostring(direction),
+                         e.what());
+    }
 }
 
 async::task<void> game_bot::process_random_pattern(const fb::model::datetime& now)

--- a/server/bot/src/game_controller.cpp
+++ b/server/bot/src/game_controller.cpp
@@ -1,6 +1,7 @@
 #include <fb/bot/game_controller.h>
 #include <fb/bot/container.h>
 #include <fb/bot/integration/protocol_registry.h>
+#include <fb/logger.h>
 
 using namespace fb::bot;
 
@@ -204,11 +205,26 @@ async::task<void> game_bot_controller::on_map(game_bot& bot, const game_resp::ma
 
 async::task<void> game_bot_controller::on_transfer(game_bot& bot, const fb::protocol::response::transfer& response)
 {
-    bot.close();
-
-    auto created  = this->create(response.parameter);
     auto ip       = boost::asio::ip::address_v4(boost::endian::endian_reverse(response.ip));
     auto endpoint = boost::asio::ip::tcp::endpoint(ip, response.port);
+
+    fb::logger::debug("bot transfer protocol: bot={} bot_id={} endpoint={}:{} param_bytes={} pending_contexts={}",
+                      bot.name(),
+                      bot.id,
+                      ip.to_string(),
+                      response.port,
+                      response.parameter.size(),
+                      this->_transfer_contexts.size());
+
+    bot.close();
+
+    auto created = this->create(response.parameter);
+    fb::logger::debug("bot transfer reconnect: bot={} old_bot_id={} new_bot_id={} endpoint={}:{}",
+                      created->name(),
+                      bot.id,
+                      created->id,
+                      ip.to_string(),
+                      response.port);
     created->connect(endpoint);
 
     co_return;
@@ -297,21 +313,53 @@ bool game_bot_controller::register_transfer_context(const fb::protocol::header& 
 {
     auto name = context->name;
     if (this->_transfer_contexts.contains(name))
+    {
+        fb::logger::warn("bot transfer register rejected: bot={} (duplicate context)", name);
         return false;
+    }
 
     this->_transfer_contexts.insert({name, context});
+    fb::logger::debug("bot transfer register: bot={} pending_contexts={}",
+                      name,
+                      this->_transfer_contexts.size());
     return true;
 }
 
 void game_bot_controller::remove_transfer_context(std::string name)
 {
-    this->_transfer_contexts.erase(name);
+    const auto erased = this->_transfer_contexts.erase(name);
+    if (erased > 0)
+    {
+        fb::logger::debug("bot transfer remove: bot={} pending_contexts={}",
+                          name,
+                          this->_transfer_contexts.size());
+    }
+    else
+    {
+        fb::logger::debug("bot transfer remove skipped: bot={} (no pending context)", name);
+    }
+}
+
+bool game_bot_controller::has_transfer_context(std::string_view name) const
+{
+    return this->_transfer_contexts.contains(std::string(name));
 }
 
 bool game_bot_controller::invoke_transfer_context(std::string name, std::shared_ptr<game_bot> bot)
 {
     if (this->_transfer_contexts.contains(name) == false)
+    {
+        fb::logger::warn("bot transfer invoke skipped: bot={} bot_id={} (no pending context, pending_contexts={})",
+                         name,
+                         bot != nullptr ? bot->id : 0,
+                         this->_transfer_contexts.size());
         return false;
+    }
+
+    fb::logger::debug("bot transfer complete: bot={} bot_id={} pending_contexts_before={}",
+                      name,
+                      bot != nullptr ? bot->id : 0,
+                      this->_transfer_contexts.size());
 
     auto context = this->_transfer_contexts[name];
     this->_transfer_contexts.erase(name);
@@ -328,7 +376,17 @@ game_bot::transfer(const fb::protocol::header& protocol, const fb::model::timesp
         this->name(),
         this->controller.weak_from_this_as<game_bot_controller>());
     auto& controller = static_cast<game_bot_controller&>(this->controller);
-    controller.register_transfer_context(protocol, context);
+    if (controller.register_transfer_context(protocol, context) == false)
+    {
+        fb::logger::warn("bot transfer start aborted: bot={} (failed to register context)", this->name());
+        promise->set_exception(std::make_exception_ptr(std::runtime_error("duplicate transfer context")));
+        return promise->task();
+    }
+
+    fb::logger::debug("bot transfer start: bot={} bot_id={} timeout_ms={}",
+                      this->name(),
+                      this->id,
+                      timeout.total_milliseconds());
 
     // Set up timeout timer if specified
     if (timeout > 0s)

--- a/server/bot/src/game_controller.cpp
+++ b/server/bot/src/game_controller.cpp
@@ -219,6 +219,7 @@ async::task<void> game_bot_controller::on_transfer(game_bot& bot, const fb::prot
     bot.close();
 
     auto created = this->create(response.parameter);
+    created->set_transfer_from_bot_id(bot.id);
     fb::logger::debug("bot transfer reconnect: bot={} old_bot_id={} new_bot_id={} endpoint={}:{}",
                       created->name(),
                       bot.id,
@@ -311,58 +312,59 @@ async::task<void> game_bot_controller::on_ping(game_bot& bot, const game_resp::p
 bool game_bot_controller::register_transfer_context(const fb::protocol::header&       protocol,
                                                     std::shared_ptr<transfer_context> context)
 {
-    auto name = context->name;
-    if (this->_transfer_contexts.contains(name))
+    auto source_bot_id = context->source_bot_id;
+    if (this->_transfer_contexts.contains(source_bot_id))
     {
-        fb::logger::warn("bot transfer register rejected: bot={} (duplicate context)", name);
+        fb::logger::warn("bot transfer register rejected: source_bot_id={} (duplicate context)", source_bot_id);
         return false;
     }
 
-    this->_transfer_contexts.insert({name, context});
-    fb::logger::debug("bot transfer register: bot={} pending_contexts={}",
-                      name,
+    this->_transfer_contexts.insert({source_bot_id, context});
+    fb::logger::debug("bot transfer register: source_bot_id={} pending_contexts={}",
+                      source_bot_id,
                       this->_transfer_contexts.size());
     return true;
 }
 
-void game_bot_controller::remove_transfer_context(std::string name)
+void game_bot_controller::remove_transfer_context(uint32_t source_bot_id)
 {
-    const auto erased = this->_transfer_contexts.erase(name);
+    const auto erased = this->_transfer_contexts.erase(source_bot_id);
     if (erased > 0)
     {
-        fb::logger::debug("bot transfer remove: bot={} pending_contexts={}",
-                          name,
+        fb::logger::debug("bot transfer remove: source_bot_id={} pending_contexts={}",
+                          source_bot_id,
                           this->_transfer_contexts.size());
     }
     else
     {
-        fb::logger::debug("bot transfer remove skipped: bot={} (no pending context)", name);
+        fb::logger::debug("bot transfer remove skipped: source_bot_id={} (no pending context)", source_bot_id);
     }
 }
 
-bool game_bot_controller::has_transfer_context(std::string_view name) const
+bool game_bot_controller::has_transfer_context(uint32_t source_bot_id) const
 {
-    return this->_transfer_contexts.contains(std::string(name));
+    return this->_transfer_contexts.contains(source_bot_id);
 }
 
-bool game_bot_controller::invoke_transfer_context(std::string name, std::shared_ptr<game_bot> bot)
+bool game_bot_controller::invoke_transfer_context(uint32_t source_bot_id, std::shared_ptr<game_bot> bot)
 {
-    if (this->_transfer_contexts.contains(name) == false)
+    if (this->_transfer_contexts.contains(source_bot_id) == false)
     {
-        fb::logger::warn("bot transfer invoke skipped: bot={} bot_id={} (no pending context, pending_contexts={})",
-                         name,
-                         bot != nullptr ? bot->id : 0,
-                         this->_transfer_contexts.size());
+        fb::logger::warn(
+            "bot transfer invoke skipped: source_bot_id={} bot_id={} (no pending context, pending_contexts={})",
+            source_bot_id,
+            bot != nullptr ? bot->id : 0,
+            this->_transfer_contexts.size());
         return false;
     }
 
-    fb::logger::debug("bot transfer complete: bot={} bot_id={} pending_contexts_before={}",
-                      name,
+    fb::logger::debug("bot transfer complete: source_bot_id={} bot_id={} pending_contexts_before={}",
+                      source_bot_id,
                       bot != nullptr ? bot->id : 0,
                       this->_transfer_contexts.size());
 
-    auto context = this->_transfer_contexts[name];
-    this->_transfer_contexts.erase(name);
+    auto context = this->_transfer_contexts[source_bot_id];
+    this->_transfer_contexts.erase(source_bot_id);
     context->complete_success(bot);
     return true;
 }
@@ -373,7 +375,7 @@ game_bot::transfer(const fb::protocol::header& protocol, const fb::model::timesp
     auto promise = std::make_shared<async::task_completion_source<std::shared_ptr<game_bot>>>();
     auto context = std::make_shared<game_bot_controller::transfer_context>(
         promise,
-        this->name(),
+        this->id,
         this->controller.weak_from_this_as<game_bot_controller>());
     auto& controller = static_cast<game_bot_controller&>(this->controller);
     if (controller.register_transfer_context(protocol, context) == false)

--- a/server/bot/src/integration/game_controller.cpp
+++ b/server/bot/src/integration/game_controller.cpp
@@ -239,13 +239,25 @@ async::task<void> game_bot_controller::on_map(game_bot& bot, const game_resp::ma
 
 async::task<void> game_bot_controller::on_transfer(game_bot& bot, const fb::protocol::response::transfer& response)
 {
-    // Integration test: Validate server transfer mechanics
-    bot.close();
-
-    // TODO: Add transfer validation and test continuation logic
-    auto created  = this->create(response.parameter);
     auto ip       = boost::asio::ip::address_v4(boost::endian::endian_reverse(response.ip));
     auto endpoint = boost::asio::ip::tcp::endpoint(ip, response.port);
+
+    fb::logger::debug("bot transfer protocol [integration]: bot={} bot_id={} endpoint={}:{} param_bytes={}",
+                      bot.name(),
+                      bot.id,
+                      ip.to_string(),
+                      response.port,
+                      response.parameter.size());
+
+    bot.close();
+
+    auto created = this->create(response.parameter);
+    fb::logger::debug("bot transfer reconnect [integration]: bot={} old_bot_id={} new_bot_id={} endpoint={}:{}",
+                      created->name(),
+                      bot.id,
+                      created->id,
+                      ip.to_string(),
+                      response.port);
     created->connect(endpoint);
 
     co_return;
@@ -266,6 +278,12 @@ async::task<void> game_bot_controller::on_bot_connected(game_bot& bot)
             this->_current_test->on_bot_connected(bot_shared);
     }
 
+    fb::logger::debug("bot transfer login send: bot={} bot_id={} transfer_buffer_bytes={} inited={}",
+                      bot.name(),
+                      bot.id,
+                      bot.transfer_buffer().size(),
+                      bot.inited());
+
     bot.send(fb::protocol::game::request::login(bot.transfer_buffer()), false, true);
 
     co_return;
@@ -273,7 +291,10 @@ async::task<void> game_bot_controller::on_bot_connected(game_bot& bot)
 
 async::task<void> game_bot_controller::on_bot_disconnected(game_bot& bot)
 {
-    fb::logger::debug("Bot {} disconnected from integration testing", bot.name());
+    fb::logger::debug("Bot {} disconnected from integration testing (bot_id={} inited={})",
+                      bot.name(),
+                      bot.id,
+                      bot.inited());
 
     // Integration test: Collect test results and perform cleanup
     // TODO: Generate test report for this bot session

--- a/server/bot/src/integration/game_controller.cpp
+++ b/server/bot/src/integration/game_controller.cpp
@@ -181,8 +181,37 @@ async::task<void> game_bot_controller::on_time(game_bot& bot, const game_resp::t
 
 async::task<void> game_bot_controller::on_state(game_bot& bot, const game_resp::update_internal& response)
 {
-    // Integration test: Validate state consistency
-    // TODO: Add state validation logic
+    if (ENUM_IN(response.level, UPDATE_STATE_LEVEL::BASED))
+    {
+        bot.set_nation(response.ch_nation);
+        bot.set_creature(response.ch_creature);
+        bot.set_level(response.ch_level);
+        bot.set_base_hp(response.ch_base_hp);
+        bot.set_base_mp(response.ch_base_mp);
+        bot.set_strength(response.ch_strength);
+        bot.set_intelligence(response.ch_intelligence);
+        bot.set_dexterity(response.ch_dexterity);
+    }
+
+    if (ENUM_IN(response.level, UPDATE_STATE_LEVEL::HP_MP))
+    {
+        bot.set_hp(response.ch_hp);
+        bot.set_mp(response.ch_mp);
+    }
+
+    if (ENUM_IN(response.level, UPDATE_STATE_LEVEL::EXP_MONEY))
+    {
+        bot.set_exp(response.ch_exp);
+        bot.set_money(response.ch_money);
+    }
+
+    if (ENUM_IN(response.level, UPDATE_STATE_LEVEL::CROWD_CONTROL))
+    {
+        bot.set_crowd_control(response.ch_crowd_control);
+    }
+
+    bot.set_mail_count(response.ch_mail);
+    bot.set_fast_move(response.ch_fast_move);
     co_return;
 }
 
@@ -252,6 +281,7 @@ async::task<void> game_bot_controller::on_transfer(game_bot& bot, const fb::prot
     bot.close();
 
     auto created = this->create(response.parameter);
+    created->set_transfer_from_bot_id(bot.id);
     fb::logger::debug("bot transfer reconnect [integration]: bot={} old_bot_id={} new_bot_id={} endpoint={}:{}",
                       created->name(),
                       bot.id,

--- a/server/bot/src/integration/login_controller.cpp
+++ b/server/bot/src/integration/login_controller.cpp
@@ -32,9 +32,8 @@ void login_bot_controller::initialize()
 async::task<void> login_bot_controller::on_agreement(login_bot& bot, const login_resp::terms_agreement& response)
 {
     // Integration test: Validate authentication flow with controlled test accounts
-    auto           id     = bot.generate_id();
-    auto           exists = false;
-    constexpr auto pw     = "admin123";
+    auto           id = bot.generate_id();
+    constexpr auto pw = "admin123";
 
     try
     {
@@ -54,21 +53,12 @@ async::task<void> login_bot_controller::on_agreement(login_bot& bot, const login
             if (resp.type == 0x0E)
             {
                 fb::logger::debug("login create rejected: bot_id={} account={} text={}", bot.id, id, resp.text);
-                if (resp.text == fb::model::const_value::string::MESSAGE_ACCOUNT_ALREADY_EXISTS)
-                {
-                    exists = true;
-                    break;
-                }
-                else
-                {
-                    id = bot.generate_id();
-                }
+                id = bot.generate_id();
             }
 
             co_await thread->sleep(100ms);
         }
 
-        if (exists == false)
         {
             // Integration test: Validate account creation with specific test parameters
             std::random_device rd;
@@ -102,8 +92,8 @@ async::task<void> login_bot_controller::on_agreement(login_bot& bot, const login
         fb::logger::debug("login auth request: bot_id={} account={}", bot.id, id);
         while (true)
         {
-            auto&& resp =
-                co_await bot.request<login_resp::message>(fb::protocol::login::request::login{id, pw}, LOGIN_REQUEST_TIMEOUT);
+            auto&& resp = co_await bot.request<login_resp::message>(fb::protocol::login::request::login{id, pw},
+                                                                    LOGIN_REQUEST_TIMEOUT);
             if (resp.type == 0x00)
                 break;
 

--- a/server/bot/src/integration/login_controller.cpp
+++ b/server/bot/src/integration/login_controller.cpp
@@ -1,8 +1,20 @@
 #include <fb/bot/integration/login_controller.h>
 #include <fb/bot/login_bot.h>
 #include <fb/bot/game_controller.h>
+#include <fb/logger.h>
 
+using namespace std::chrono_literals;
 using namespace fb::bot::integration;
+
+namespace {
+
+#ifdef _DEBUG
+constexpr auto LOGIN_REQUEST_TIMEOUT = 30s;
+#else
+constexpr auto LOGIN_REQUEST_TIMEOUT = 10s;
+#endif
+
+} // namespace
 
 login_bot_controller::login_bot_controller(bot_container& container) :
     fb::bot::login_bot_controller(container)
@@ -28,16 +40,20 @@ async::task<void> login_bot_controller::on_agreement(login_bot& bot, const login
     {
         auto thread = bot.thread();
 
-        // TODO: Add authentication flow validation logic
+        fb::logger::debug("login flow start: bot_id={} account={}", bot.id, id);
+
         while (true)
         {
-            auto&& resp = co_await bot.request<login_resp::message>(fb::protocol::login::request::create(id, pw));
+            fb::logger::debug("login create request: bot_id={} account={}", bot.id, id);
+            auto&& resp = co_await bot.request<login_resp::message>(fb::protocol::login::request::create(id, pw),
+                                                                    LOGIN_REQUEST_TIMEOUT);
 
             if (resp.type == 0x00)
                 break;
 
             if (resp.type == 0x0E)
             {
+                fb::logger::debug("login create rejected: bot_id={} account={} text={}", bot.id, id, resp.text);
                 if (resp.text == fb::model::const_value::string::MESSAGE_ACCOUNT_ALREADY_EXISTS)
                 {
                     exists = true;
@@ -63,36 +79,43 @@ async::task<void> login_bot_controller::on_agreement(login_bot& bot, const login
             uint8_t nation   = std::uniform_int_distribution<>(1, 2)(gen);
             uint8_t creature = std::uniform_int_distribution<>(0, 3)(gen);
 
+            fb::logger::debug("login complete request: bot_id={} account={}", bot.id, id);
             while (true)
             {
                 auto&& resp = co_await bot.request<login_resp::message>(
-                    fb::protocol::login::request::complete{hair, gender, nation, creature});
+                    fb::protocol::login::request::complete{hair, gender, nation, creature},
+                    LOGIN_REQUEST_TIMEOUT);
 
                 if (resp.type == 0x00)
                     break;
 
+                fb::logger::debug("login complete rejected: bot_id={} type=0x{:02X} text={}",
+                                  bot.id,
+                                  resp.type,
+                                  resp.text);
                 co_await thread->sleep(100ms);
             }
 
             // TODO: Validate character creation parameters
         }
 
-        // Integration test: Validate login authentication
+        fb::logger::debug("login auth request: bot_id={} account={}", bot.id, id);
         while (true)
         {
-            auto&& resp = co_await bot.request<login_resp::message>(fb::protocol::login::request::login{id, pw});
+            auto&& resp =
+                co_await bot.request<login_resp::message>(fb::protocol::login::request::login{id, pw}, LOGIN_REQUEST_TIMEOUT);
             if (resp.type == 0x00)
                 break;
 
+            fb::logger::debug("login auth rejected: bot_id={} type=0x{:02X} text={}", bot.id, resp.type, resp.text);
             co_await thread->sleep(1000ms);
         }
 
-        // TODO: Validate successful authentication and session establishment
+        fb::logger::debug("login flow done: bot_id={} account={}", bot.id, id);
     }
     catch (std::exception& e)
     {
-        // TODO: Log authentication errors for test analysis
-        std::cout << e.what() << std::endl;
+        fb::logger::fatal("login flow failed: bot_id={} account={} error={}", bot.id, id, e.what());
     }
 
     co_return;
@@ -100,13 +123,13 @@ async::task<void> login_bot_controller::on_agreement(login_bot& bot, const login
 
 async::task<void> login_bot_controller::on_transfer(login_bot& bot, const fb_resp::transfer& response)
 {
-    // Integration test: Validate login-to-game server transition
-    bot.close();
-
-    // TODO: Add transfer validation and test continuation logic
-    auto created  = this->container.game->create(response.parameter);
     auto ip       = boost::asio::ip::address_v4(boost::endian::endian_reverse(response.ip));
     auto endpoint = boost::asio::ip::tcp::endpoint(ip, response.port);
+    fb::logger::debug("login transfer: bot_id={} game={}:{}", bot.id, ip.to_string(), response.port);
+
+    bot.close();
+
+    auto created = this->container.game->create(response.parameter);
     created->connect(endpoint);
 
     // TODO: Validate seamless transition to game server

--- a/server/bot/src/integration/test/test_case.cpp
+++ b/server/bot/src/integration/test/test_case.cpp
@@ -313,7 +313,7 @@ async::task<void> bot_integration_test::on_hook_update_external(fb::bot::game_bo
     if (bot.oid() == 0)
         bot.set_oid(resp.oid);
 
-    if (bot.inited() == false)
+    if (this->controller.has_transfer_context(bot.name()))
     {
         auto reconnected_index = std::optional<uint32_t>{};
         auto it                = std::find_if(this->_test_bots.begin(), this->_test_bots.end(), [&bot](auto& b) {
@@ -332,12 +332,29 @@ async::task<void> bot_integration_test::on_hook_update_external(fb::bot::game_bo
             }
         }
 
+        fb::logger::debug("bot transfer hook: test={} bot={} bot_id={} oid={} inited={} reconnected_index={}",
+                          this->name(),
+                          bot.name(),
+                          bot.id,
+                          bot.oid(),
+                          bot.inited(),
+                          reconnected_index.has_value() ? std::to_string(reconnected_index.value()) : "none");
+
         if (reconnected_index.has_value())
         {
             this->_test_bots[reconnected_index.value()] = std::move(*it);
             this->_test_bots.erase(it);
         }
-        this->controller.invoke_transfer_context(bot.name(), bot.shared_from_this_as<game_bot>());
+
+        const auto invoked =
+            this->controller.invoke_transfer_context(bot.name(), bot.shared_from_this_as<game_bot>());
+        if (invoked == false)
+        {
+            fb::logger::warn("bot transfer hook: test={} bot={} bot_id={} invoke_transfer_context failed",
+                             this->name(),
+                             bot.name(),
+                             bot.id);
+        }
     }
 
     this->mark_bot_logged_in(bot);

--- a/server/bot/src/integration/test/test_case.cpp
+++ b/server/bot/src/integration/test/test_case.cpp
@@ -92,6 +92,71 @@ void bot_integration_test::mark_bot_logged_in(game_bot& bot)
         bot.inited(true);
 }
 
+void bot_integration_test::try_complete_transfer(game_bot& bot)
+{
+    const auto source_bot_id = bot.transfer_from_bot_id();
+    if (source_bot_id == 0)
+        return;
+
+    if (this->controller.has_transfer_context(source_bot_id) == false)
+        return;
+
+    auto reconnected_index = std::optional<uint32_t>{};
+    auto it                = std::find_if(this->_test_bots.begin(), this->_test_bots.end(), [&bot](auto& b) {
+        return b.get() == &bot;
+    });
+    for (uint32_t i = 0; i < this->_test_bots.size(); i++)
+    {
+        auto& b = this->_test_bots[i];
+        if (&bot == b.get())
+            continue;
+
+        if (b->id == source_bot_id)
+        {
+            reconnected_index = i;
+            break;
+        }
+    }
+
+    fb::logger::debug(
+        "bot transfer hook: test={} bot={} bot_id={} source_bot_id={} oid={} inited={} reconnected_index={}",
+        this->name(),
+        bot.name(),
+        bot.id,
+        source_bot_id,
+        bot.oid(),
+        bot.inited(),
+        reconnected_index.has_value() ? std::to_string(reconnected_index.value()) : "none");
+
+    if (reconnected_index.has_value() && it != this->_test_bots.end())
+    {
+        this->_test_bots[reconnected_index.value()] = std::move(*it);
+        this->_test_bots.erase(it);
+
+        const auto invoked =
+            this->controller.invoke_transfer_context(source_bot_id, bot.shared_from_this_as<game_bot>());
+        if (invoked)
+            bot.set_transfer_from_bot_id(0);
+        else
+        {
+            fb::logger::warn(
+                "bot transfer hook: test={} bot={} bot_id={} source_bot_id={} invoke_transfer_context failed",
+                this->name(),
+                bot.name(),
+                bot.id,
+                source_bot_id);
+        }
+    }
+    else
+    {
+        fb::logger::debug("bot transfer hook skipped: test={} bot={} bot_id={} source_bot_id={} (awaiting reconnect)",
+                          this->name(),
+                          bot.name(),
+                          bot.id,
+                          source_bot_id);
+    }
+}
+
 void bot_integration_test::try_notify_ready()
 {
     if (this->is_ready() == false)
@@ -313,49 +378,7 @@ async::task<void> bot_integration_test::on_hook_update_external(fb::bot::game_bo
     if (bot.oid() == 0)
         bot.set_oid(resp.oid);
 
-    if (this->controller.has_transfer_context(bot.name()))
-    {
-        auto reconnected_index = std::optional<uint32_t>{};
-        auto it                = std::find_if(this->_test_bots.begin(), this->_test_bots.end(), [&bot](auto& b) {
-            return b.get() == &bot;
-        });
-        for (int i = 0; i < this->_test_bots.size(); i++)
-        {
-            auto& b = this->_test_bots[i];
-            if (&bot == b.get())
-                continue;
-
-            if (b->name() == bot.name())
-            {
-                reconnected_index = i;
-                break;
-            }
-        }
-
-        fb::logger::debug("bot transfer hook: test={} bot={} bot_id={} oid={} inited={} reconnected_index={}",
-                          this->name(),
-                          bot.name(),
-                          bot.id,
-                          bot.oid(),
-                          bot.inited(),
-                          reconnected_index.has_value() ? std::to_string(reconnected_index.value()) : "none");
-
-        if (reconnected_index.has_value())
-        {
-            this->_test_bots[reconnected_index.value()] = std::move(*it);
-            this->_test_bots.erase(it);
-        }
-
-        const auto invoked =
-            this->controller.invoke_transfer_context(bot.name(), bot.shared_from_this_as<game_bot>());
-        if (invoked == false)
-        {
-            fb::logger::warn("bot transfer hook: test={} bot={} bot_id={} invoke_transfer_context failed",
-                             this->name(),
-                             bot.name(),
-                             bot.id);
-        }
-    }
+    this->try_complete_transfer(bot);
 
     this->mark_bot_logged_in(bot);
     this->try_notify_ready();
@@ -367,6 +390,8 @@ async::task<void> bot_integration_test::on_hook_update_external_brief(fb::bot::g
 {
     if (bot.oid() == 0)
         bot.set_oid(resp.oid);
+
+    this->try_complete_transfer(bot);
 
     if (bot.oid() == resp.oid)
         this->mark_bot_logged_in(bot);

--- a/server/game/config/config.dev.json
+++ b/server/game/config/config.dev.json
@@ -50,6 +50,6 @@
     "exp_multiplier": 100.0,
     "drop_rate_multiplier": 100.0,
     "http": {
-        "max_concurrent": 500
+        "max_concurrent": 128
     }
 }

--- a/server/game/model.additional.h
+++ b/server/game/model.additional.h
@@ -368,14 +368,14 @@ public:                                                                         
 #define DECLARE_BLOCKED_WORD_CONTAINER_CUSTOM_CONSTRUCTOR \
     __blocked_word();                                     \
     __blocked_word(const __blocked_word&) = delete;       \
-    ~__blocked_word() = default;
+    ~__blocked_word()                     = default;
 
-#define DECLARE_BLOCKED_WORD_CONTAINER_EXTENSION \
-                                                 \
-public:                                          \
+#define DECLARE_BLOCKED_WORD_CONTAINER_EXTENSION        \
+                                                        \
+public:                                                 \
     std::string filter(std::string_view message) const; \
-                                                   \
-private:                                           \
+                                                        \
+private:                                                \
     fb::model::substring_matcher _matcher;
 
 #define DECLARE_RECIPE_EXTENSION                       \

--- a/server/game/scripts/interaction.lua
+++ b/server/game/scripts/interaction.lua
@@ -192,7 +192,7 @@ function on_door(me)
     local key = me:item('파란열쇠')
     local locked = door:locked()
     if door:locked() and key == nil then
-        me:message('문이 잠겨있습니다.')
+        me:message('문이 잠겼습니다.')
         return
     end
 

--- a/server/game/src/map/container.cpp
+++ b/server/game/src/map/container.cpp
@@ -228,17 +228,70 @@ void map::container::spawn_npc(const fb::model::npc_spawn& spawn, const std::sha
     auto& npc_model = table::npc[spawn.npc];
     auto  npc       = this->server.make<fb::game::npc>(npc_model);
     auto  weak      = npc->weak_from_this_as<fb::game::npc>();
+    auto  position  = spawn.position;
+    auto  direction = spawn.direction;
     auto  fn        = [](std::shared_ptr<fb::game::npc> npc,
                  std::shared_ptr<fb::game::map> map,
-                 const fb::model::npc_spawn&    spawn_model) -> async::task<void> {
-        std::ignore = co_await npc->map(map, spawn_model.position);
-        npc->direction(spawn_model.direction);
+                 fb::model::point16_t           position,
+                 DIRECTION                      direction) -> async::task<void> {
+        std::ignore = co_await npc->map(map, position);
+        npc->direction(direction);
     };
     auto builder = this->server.threads.new_builder(weak);
-    builder.func = [fn, npc, map, &spawn](auto&) -> async::task<void> {
-        co_await fn(npc, map, spawn);
+    builder.func = [fn, npc, map, position, direction](auto&) -> async::task<void> {
+        co_await fn(npc, map, position, direction);
     };
     builder.enqueue();
+}
+
+async::task<void> map::container::cleanup()
+{
+    auto maps_division = std::unordered_map<fb::thread*, std::vector<std::shared_ptr<fb::game::map>>>{};
+    for (auto& [id, map] : *this)
+    {
+        std::ignore = id;
+        if (map->loaded() == false)
+            continue;
+
+        auto thread = map->thread();
+        if (thread == nullptr)
+            continue;
+
+        maps_division[thread].push_back(map);
+    }
+
+    auto tasks = std::vector<async::task<void>>{};
+    for (auto& [thread, maps] : maps_division)
+    {
+        auto builder = thread->new_builder<void>();
+        builder.func = [maps = std::move(maps)](auto&) -> async::task<void> {
+            for (const auto& map : maps)
+            {
+                auto objects = std::vector<std::shared_ptr<fb::game::object>>{};
+                for (auto& [seq, obj] : map->objects)
+                {
+                    std::ignore = seq;
+                    if (obj->is(OBJECT_TYPE::CHARACTER))
+                        continue;
+
+                    objects.push_back(obj);
+                }
+
+                for (auto& obj : objects)
+                {
+                    co_await obj->destroy();
+                }
+            }
+            co_return;
+        };
+        tasks.push_back(builder.dispatch());
+    }
+
+    for (auto& task : tasks)
+    {
+        co_await task;
+    }
+    co_return;
 }
 
 std::shared_ptr<fb::game::map> map::container::name2map(std::string_view name) const

--- a/server/game/src/server/server.event.cpp
+++ b/server/game/src/server/server.event.cpp
@@ -7,6 +7,7 @@
 
 using namespace fb::game;
 using namespace fb::model::enum_value;
+using namespace std::chrono_literals;
 
 namespace game_reqs     = fb::protocol::game::request;
 namespace internal      = fb::protocol::internal;
@@ -134,6 +135,25 @@ async::task<bool> fb::game::server::on_disconnected(fb::socket<character>& socke
 async::task<void> fb::game::server::on_exit()
 {
     co_await this->save();
+
+    while (true)
+    {
+        auto pending = size_t{0};
+        for (uint8_t i = 0; i < this->threads.count(); ++i)
+        {
+            auto thread = this->threads.at(i);
+            if (thread != nullptr)
+                pending += thread->queue_size();
+        }
+
+        if (pending == 0)
+            break;
+
+        co_await this->sleep(10ms);
+    }
+
+    co_await this->maps.cleanup();
+    co_return;
 }
 
 uint32_t fb::game::server::thread_id(const fb::socket<character>& socket) const

--- a/server/game/src/server/server.init.cpp
+++ b/server/game/src/server/server.init.cpp
@@ -283,7 +283,7 @@ async::task<void> fb::game::server::init_script()
 }
 
 fb::game::server::server(boost::asio::io_context& io_context, uint16_t port) :
-    fb::acceptor<character>(io_context, "GAME", port, fb::config<uint32_t>("http:max_concurrent", 500)),
+    fb::acceptor<character>(io_context, "GAME", port, fb::config<uint32_t>("http:max_concurrent", 128)),
     maps(*this, fb::config<uint32_t>("id")),
     listener(*this),
     characters(*this),

--- a/server/game/src/service/system_mail.cpp
+++ b/server/game/src/service/system_mail.cpp
@@ -76,6 +76,21 @@ fb::async_generator<void> service::system_mail::delivery_coroutine()
 {
     while (true)
     {
+        character::container::online_snapshot_t online_users;
+        {
+            auto guard   = this->server.characters.enter_read();
+            online_users = guard.value().online_users();
+        }
+
+        const auto now = this->server.now();
+        prune_expired_mails(this->_pending_mails, now);
+
+        if (online_users.empty())
+        {
+            co_await fb::async_suspend{};
+            continue;
+        }
+
         auto        max_mail_id = uint32_t{0};
         const auto  world       = fb::config<uint32_t>("world");
         const auto& fetch_url   = std::format("/mail/system/{}?offset={}", world, this->_poll_offset);
@@ -85,7 +100,6 @@ fb::async_generator<void> service::system_mail::delivery_coroutine()
             auto&& resp = co_await this->server.http.get<internal_resp::GetSystemMails>("internal", fetch_url);
             if (resp.error == 0)
             {
-                const auto now = this->server.now();
                 for (const auto& dto : resp.mails)
                 {
                     auto mail = from_system_mail_dto(dto);
@@ -111,14 +125,6 @@ fb::async_generator<void> service::system_mail::delivery_coroutine()
 
         if (max_mail_id > 0)
             this->_poll_offset = max_mail_id + 1;
-
-        const auto                              now = this->server.now();
-        character::container::online_snapshot_t online_users;
-        {
-            auto guard   = this->server.characters.enter_read();
-            online_users = guard.value().online_users();
-        }
-        prune_expired_mails(this->_pending_mails, now);
 
         for (const auto& mail : this->_pending_mails)
         {

--- a/server/game/src/service/system_storage.cpp
+++ b/server/game/src/service/system_storage.cpp
@@ -221,6 +221,18 @@ async::task<void> service::system_storage::create(uint32_t                      
 
 async::task<void> service::system_storage::poll_and_deliver()
 {
+    character::container::online_snapshot_t online_users;
+    {
+        auto guard   = this->server.characters.enter_read();
+        online_users = guard.value().online_users();
+    }
+
+    const auto now = this->server.now();
+    prune_expired_boxes(this->_pending_boxes, now);
+
+    if (online_users.empty())
+        co_return;
+
     auto        max_box_id = uint32_t{0};
     const auto  world      = fb::config<uint32_t>("world");
     const auto& fetch_url  = std::format("/storage/system/{}?offset={}", world, this->_poll_offset);
@@ -230,7 +242,6 @@ async::task<void> service::system_storage::poll_and_deliver()
         auto&& resp = co_await this->server.http.get<internal_resp::GetSystemStorageBoxes>("internal", fetch_url);
         if (resp.error == 0)
         {
-            const auto now = this->server.now();
             for (const auto& dto : resp.boxes)
             {
                 auto box = from_system_storage_dto(dto);
@@ -256,14 +267,6 @@ async::task<void> service::system_storage::poll_and_deliver()
 
     if (max_box_id > 0)
         this->_poll_offset = max_box_id + 1;
-
-    const auto                              now = this->server.now();
-    character::container::online_snapshot_t online_users;
-    {
-        auto guard   = this->server.characters.enter_read();
-        online_users = guard.value().online_users();
-    }
-    prune_expired_boxes(this->_pending_boxes, now);
 
     for (const auto& box : this->_pending_boxes)
     {

--- a/server/gateway/config/config.dev.json
+++ b/server/gateway/config/config.dev.json
@@ -44,7 +44,7 @@
         }
     },
     "http": {
-        "max_concurrent": 500
+        "max_concurrent": 128
     },
     "client": {
         "version": 550,

--- a/server/gateway/src/server.cpp
+++ b/server/gateway/src/server.cpp
@@ -11,7 +11,7 @@ using namespace std::chrono_literals;
 namespace internal_reqs = fb::protocol::internal::request;
 
 server::server(boost::asio::io_context& io_context, uint16_t port) :
-    fb::acceptor<session>(io_context, "GATEWAY", port, fb::config<uint32_t>("http:max_concurrent", 500)),
+    fb::acceptor<session>(io_context, "GATEWAY", port, fb::config<uint32_t>("http:max_concurrent", 128)),
     log(fb::config<std::string>("amqp:log:ip"),
         fb::config<uint16_t>("amqp:log:port"),
         fb::config<std::string>("amqp:log:uid"),

--- a/server/login/config/config.dev.json
+++ b/server/login/config/config.dev.json
@@ -66,6 +66,6 @@
         "max": 14
     },
     "http": {
-        "max_concurrent": 500
+        "max_concurrent": 128
     }
 }

--- a/server/login/model.additional.h
+++ b/server/login/model.additional.h
@@ -8,20 +8,20 @@
 #define DECLARE_BLOCKED_NAME_CONTAINER_CUSTOM_CONSTRUCTOR \
     __blocked_name();                                     \
     __blocked_name(const __blocked_name&) = delete;       \
-    ~__blocked_name() = default;
+    ~__blocked_name()                     = default;
 
-#define DECLARE_BLOCKED_NAME_CONTAINER_EXTENSION \
-                                                 \
-public:                                          \
+#define DECLARE_BLOCKED_NAME_CONTAINER_EXTENSION          \
+                                                          \
+public:                                                   \
     bool contains_substring(std::string_view name) const; \
-                                                   \
-private:                                           \
+                                                          \
+private:                                                  \
     fb::model::substring_matcher _matcher;
 
 #define DECLARE_BLOCKED_WORD_CONTAINER_CUSTOM_CONSTRUCTOR \
     __blocked_word();                                     \
     __blocked_word(const __blocked_word&) = delete;       \
-    ~__blocked_word() = default;
+    ~__blocked_word()                     = default;
 
 #define DECLARE_BLOCKED_WORD_CONTAINER_EXTENSION                 \
                                                                  \

--- a/server/login/src/server.cpp
+++ b/server/login/src/server.cpp
@@ -14,7 +14,7 @@ using namespace fb::login;
 namespace internal_reqs = fb::protocol::internal::request;
 
 fb::login::server::server(boost::asio::io_context& io_context, uint16_t port) :
-    fb::acceptor<session>(io_context, "LOGIN", port, fb::config<uint32_t>("http:max_concurrent", 500)),
+    fb::acceptor<session>(io_context, "LOGIN", port, fb::config<uint32_t>("http:max_concurrent", 128)),
     log(fb::config<std::string>("amqp:log:ip"),
         fb::config<uint16_t>("amqp:log:port"),
         fb::config<std::string>("amqp:log:uid"),

--- a/tools/runner/ViewModel/MainWindow.cs
+++ b/tools/runner/ViewModel/MainWindow.cs
@@ -830,7 +830,7 @@ namespace Runner.ViewModel
                     conf["drop_rate_multiplier"] = 100.0;
                     conf["http"] = JObject.FromObject(new
                     {
-                        max_concurrent = 500
+                        max_concurrent = 128
                     });
                     File.WriteAllText(Path.Combine([gameDir, $"config_game_{setting.ID}.json"]), conf.ToString(Formatting.Indented));
                 }


### PR DESCRIPTION
## Summary

Improve server stability, bot transfer reliability, and integration test coverage across shutdown cleanup, config/acceptor/HTTP client fixes, bot transfer tracking, and door/skill test hardening.

## Server stability

- Clean up non-character map objects on shutdown and drain logic thread queues first
- Fix NPC spawn position/direction capture in async lambda (value capture)
- Load config on main thread in `init_config` to avoid worker-thread ifstream UBSan crashes
- Harden acceptor socket lifecycle (close on disconnect, fd reuse handling, shared_ptr lifetime)

## HTTP client

- Deduplicate GET/POST async exchange path with shared deadline timer and socket cancel on timeout
- Reduce outbound HTTP `max_concurrent` from 500 to 128 (game/login/gateway configs, Pulumi, runner)

## Bot transfer

- Key transfer contexts by source bot id instead of bot name
- Record transfer source on reconnect; complete hooks via `has_transfer_context` on `update_external`
- Skip external update when bot oid is unset
- Fix Lua `builtin_transfer` weak_ptr refresh after `co_await`
- Sync integration bot state from `update_internal` packets
- Add transfer register/complete/timeout diagnostic logging

## Integration tests

- Retry account creation with a new generated id on login rejection
- Allow `lua_arg_error` to return through longjmp (remove `noreturn`)
- Harden door test toggle sequence with settle delays and debug logging on failure
- Fix 공력주입 MP assertion via `request_on` on target bot plus 1s sleep before caster MP check
- Improve `special.lua` `restore_position` transfer path

## Other

- Align locked door message text to `문이 잠겼습니다.`
- Skip system mail/storage HTTP poll when no online users
- Apply clang-format alignment fixes